### PR TITLE
ci: add clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+Checks: 'clang-analyzer-*,bugprone-*,modernize-*,readability-*,cppcoreguidelines-*,performance-*,concurrency-*,cert-*,google-*'
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*'

--- a/.github/workflows/bazel_build.yml
+++ b/.github/workflows/bazel_build.yml
@@ -1,9 +1,6 @@
 name: Bazel Build
 
 on:
-  push:
-    branches:
-      - '*'
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/bazel_test.yml
+++ b/.github/workflows/bazel_test.yml
@@ -1,9 +1,6 @@
 name: Bazel Test
 
 on:
-  push:
-    branches:
-      - '*'
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -27,7 +27,8 @@ jobs:
 
     - name: Run Clang-Tidy
       run: |
-        files=$(find . -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cxx" -o -name "*.hxx")
+        files=$(find . \( -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cxx" -o -name "*.hxx" \) -not -name "test*.cpp")
+
         echo "Files to analyze: $files"
         echo "Running clang tidy"
         echo "$files" | xargs clang-tidy
@@ -36,4 +37,4 @@ jobs:
       if: failure()
       run: |
         echo -e "To automatically apply suggested fixes, run the following command:
-        find . -name \"*.cpp\" -o -name \"*.h\" -o -name \"*.hpp\" -o -name \"*.cc\" -o -name \"*.cxx\" -o -name \"*.hxx\" | xargs clang-tidy -fix -fix-errors"
+        find . \( -name \"*.cpp\" -o -name \"*.h\" -o -name \"*.hpp\" -o -name \"*.cc\" -o -name \"*.cxx\" -o -name \"*.hxx\" \) -not -name \"test*.cpp\" | xargs clang-tidy -fix -fix-errors"

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -1,0 +1,39 @@
+name: Clang-Tidy
+
+on:
+  pull_request:
+    branches:
+      - '*'
+    paths:
+      - '**.cpp'
+      - '**.h'
+      - '**.hpp'
+      - '**.cc'
+      - '**.cxx'
+      - '**.hxx'
+
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-tidy
+
+    - name: Run Clang-Tidy
+      run: |
+        files=$(find . -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cxx" -o -name "*.hxx")
+        echo "Files to analyze: $files"
+        echo "Running clang tidy"
+        echo "$files" | xargs clang-tidy
+
+    - name: Show failure message
+      if: failure()
+      run: |
+        echo -e "To automatically apply suggested fixes, run the following command:
+        find . -name \"*.cpp\" -o -name \"*.h\" -o -name \"*.hpp\" -o -name \"*.cc\" -o -name \"*.cxx\" -o -name \"*.hxx\" | xargs clang-tidy -fix -fix-errors"

--- a/examples/cpp/hello.cpp
+++ b/examples/cpp/hello.cpp
@@ -4,3 +4,7 @@
 std::string greet() {
     return "Hello World!";
 }
+
+std::string farewell() {
+    return "Bye World!";
+}

--- a/examples/cpp/hello.cpp
+++ b/examples/cpp/hello.cpp
@@ -1,10 +1,10 @@
 #include "hello.hpp"
 #include <string>
 
-std::string greet() {
+auto greet() -> std::string {
     return "Hello World!";
 }
 
-std::string farewell() {
+auto farewell() -> std::string {
     return "Bye World!";
 }

--- a/examples/cpp/hello.hpp
+++ b/examples/cpp/hello.hpp
@@ -4,5 +4,6 @@
 #include <string>
 
 std::string greet();
+std::string farewell();
 
 #endif

--- a/examples/cpp/hello.hpp
+++ b/examples/cpp/hello.hpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-std::string greet();
-std::string farewell();
+auto greet() -> std::string;
+auto farewell() -> std::string;
 
 #endif

--- a/examples/cpp/main.cpp
+++ b/examples/cpp/main.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 #include <string>
 
-int main(int argc, char** argv) {
-  std::cout << greet() << std::endl;
+auto main(int argc, char** argv) -> int {
+  std::cout << greet() << '\n';
   return 0;
 }


### PR DESCRIPTION
Problem with including gtest, clang-tidy throws error.
Bazel doesnt allow to create compilation database.
Easiest solution is to ignore test files, and dont run clang-tidy on test files (regex `test*.cpp`).