### PR TITLE
bazel: add warning options and treat warnings as errors

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,48 @@
 startup --output_user_root=/tmp/bazel_output
 build --verbose_failures
+
+# Warning options follow https://github.com/cpp-best-practices/cppbestpractices/blob/master/02-Use_the_Tools_Available.md#gcc%E2%80%94clang
+build --cxxopt=-Wall
+build --cxxopt=-Wextra
+build --cxxopt=-Wshadow
+build --cxxopt=-Wnon-virtual-dtor
+build --cxxopt=-Wold-style-cast
+build --cxxopt=-Wcast-align
+build --cxxopt=-Wunused
+build --cxxopt=-Woverloaded-virtual
+build --cxxopt=-Wpedantic
+build --cxxopt=-Wconversion
+build --cxxopt=-Wsign-conversion
+build --cxxopt=-Wmisleading-indentation
+build --cxxopt=-Wduplicated-cond
+build --cxxopt=-Wduplicated-branches
+build --cxxopt=-Wlogical-op
+build --cxxopt=-Wnull-dereference
+build --cxxopt=-Wuseless-cast
+build --cxxopt=-Wdouble-promotion
+build --cxxopt=-Wformat=2
+build --cxxopt=-Wimplicit-fallthrough
+build --cxxopt=-Werror
+# build --per_file_copt=-external/.*@-Wlifetime # not compatible with gcc
+
+build --per_file_copt=external/.*@-Wno-all
+build --per_file_copt=external/.*@-Wno-extra
+build --per_file_copt=external/.*@-Wno-shadow
+build --per_file_copt=external/.*@-Wno-non-virtual-dtor
+build --per_file_copt=external/.*@-Wno-old-style-cast
+build --per_file_copt=external/.*@-Wno-cast-align
+build --per_file_copt=external/.*@-Wno-unused
+build --per_file_copt=external/.*@-Wno-overloaded-virtual
+build --per_file_copt=external/.*@-Wno-pedantic
+build --per_file_copt=external/.*@-Wno-conversion
+build --per_file_copt=external/.*@-Wno-sign-conversion
+build --per_file_copt=external/.*@-Wno-misleading-indentation
+build --per_file_copt=external/.*@-Wno-duplicated-cond
+build --per_file_copt=external/.*@-Wno-duplicated-branches
+build --per_file_copt=external/.*@-Wno-logical-op
+build --per_file_copt=external/.*@-Wno-null-dereference
+build --per_file_copt=external/.*@-Wno-useless-cast
+build --per_file_copt=external/.*@-Wno-double-promotion
+build --per_file_copt=external/.*@-Wno-implicit-fallthrough
+build --per_file_copt=external/.*@-Wno-error
+# build --per_file_copt=-external/.*@-Wlifetime # not compatible with gcc

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,3 @@
-Checks: 'clang-analyzer-*,bugprone-*,modernize-*,readability-*,cppcoreguidelines-*,performance-*,concurrency-*,cert-*,google-*'
+Checks: 'clang-analyzer-*,bugprone-*,modernize-*,readability-*,cppcoreguidelines-*,performance-*,concurrency-*,cert-*,google-*,misc-*'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'

--- a/examples/cpp/main.cpp
+++ b/examples/cpp/main.cpp
@@ -1,8 +1,7 @@
 #include "hello.hpp"
 #include <iostream>
-#include <string>
 
-auto main(int argc, char** argv) -> int {
+auto main(int  /*argc*/, char**  /*argv*/) -> int {
   std::cout << greet() << '\n';
   return 0;
 }


### PR DESCRIPTION
Warnings options added in .bazelrc.
Warnings treated as errors.
`third_party` and `external` where excluded.
The implementation of [bazel features](https://bazel.build/docs/cc-toolchain-config-reference) can be investigated on a follow-up.