### PR TITLE
bazel: add support for qt with hello world example

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -64,3 +64,17 @@ http_archive(
         "https://github.com/bazelbuild/buildtools/archive/refs/tags/4.2.2.tar.gz",
     ],
 )
+
+git_repository(
+    name = "rules_qt",
+    branch = "main",
+    remote = "https://github.com/Vertexwahn/rules_qt6.git",
+)
+
+load("@rules_qt//:fetch_qt.bzl", "fetch_qt6")
+
+fetch_qt6()
+
+load("@rules_qt//tools:qt_toolchain.bzl", "register_qt_toolchains")
+
+register_qt_toolchains()

--- a/examples/qt/BUILD
+++ b/examples/qt/BUILD
@@ -1,0 +1,19 @@
+load("@rules_qt//:qt.bzl", "qt_cc_binary", "qt_cc_library")
+
+qt_cc_library(
+    name = "lib",
+    srcs = ["hello.cpp"],
+    hdrs = ["hello.hpp"],
+    deps = [
+        "@rules_qt//:qt_core",
+        "@rules_qt//:qt_widgets",
+    ],
+)
+
+qt_cc_binary(
+    name = "bin",
+    srcs = ["main.cpp"],
+    deps = [
+        ":lib",
+    ],
+)

--- a/examples/qt/README
+++ b/examples/qt/README
@@ -1,0 +1,5 @@
+# How to Run
+
+```bash
+bazel run //examples/qt:bin
+```

--- a/examples/qt/hello.cpp
+++ b/examples/qt/hello.cpp
@@ -1,0 +1,16 @@
+#include "hello.hpp"
+#include <QLabel>
+#include <memory>
+#include <qlabel.h>
+
+MyWidget::MyWidget() {
+    constexpr int LabelXPos = 100;
+    constexpr int LabelYPos = 100;
+
+    auto label = std::make_unique<QLabel>(this);
+
+    label->move(LabelXPos, LabelYPos);
+    setWindowTitle("Hello World");
+};
+
+MyWidget::~MyWidget() = default;

--- a/examples/qt/hello.hpp
+++ b/examples/qt/hello.hpp
@@ -1,0 +1,13 @@
+#include <qwidget.h>
+#include <QWidget>
+
+class MyWidget : public QWidget
+{
+public:
+    MyWidget();
+    ~MyWidget() override;
+    MyWidget(const MyWidget&) = delete;
+    auto operator=(const MyWidget&) -> MyWidget& = delete;
+    MyWidget(MyWidget&&) = delete;
+    auto operator=(MyWidget&&) -> MyWidget& = delete;
+};

--- a/examples/qt/main.cpp
+++ b/examples/qt/main.cpp
@@ -1,0 +1,17 @@
+#include "hello.hpp"
+#include <QApplication>
+#include <qapplication.h>
+#include <memory>
+
+auto main(int argc, char **argv) -> int {
+    QApplication const app(argc, argv);
+
+    const int WindowWidth = 600;
+    const int WindowHeight = 600;
+
+    auto mainWidget = std::make_unique<MyWidget>();
+    mainWidget->resize(WindowWidth, WindowHeight);
+    mainWidget->show();
+
+    return QApplication::exec();
+}


### PR DESCRIPTION
Qt is hermetic, meaning it automatically downloads.

How to run example:

```bash
bazel run //examples/qt:bin
```

Issue: https://github.com/SEAME-pt/jet_racers/issues/28
