### PR TITLE
ci: run clang-tidy with compile commands option

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,48 +1,14 @@
 startup --output_user_root=/tmp/bazel_output
 build --verbose_failures
+build --repo_env=CC=clang
+build --cxxopt=-std=c++20
 
 # Warning options follow https://github.com/cpp-best-practices/cppbestpractices/blob/master/02-Use_the_Tools_Available.md#gcc%E2%80%94clang
-build --cxxopt=-Wall
-build --cxxopt=-Wextra
-build --cxxopt=-Wshadow
-build --cxxopt=-Wnon-virtual-dtor
-build --cxxopt=-Wold-style-cast
-build --cxxopt=-Wcast-align
-build --cxxopt=-Wunused
-build --cxxopt=-Woverloaded-virtual
-build --cxxopt=-Wpedantic
-build --cxxopt=-Wconversion
-build --cxxopt=-Wsign-conversion
-build --cxxopt=-Wmisleading-indentation
-build --cxxopt=-Wduplicated-cond
-build --cxxopt=-Wduplicated-branches
-build --cxxopt=-Wlogical-op
-build --cxxopt=-Wnull-dereference
-build --cxxopt=-Wuseless-cast
-build --cxxopt=-Wdouble-promotion
-build --cxxopt=-Wformat=2
-build --cxxopt=-Wimplicit-fallthrough
+build --cxxopt=-Weverything # incompatible with gcc
 build --cxxopt=-Werror
-# build --cxxopt=-Wlifetime # incompatible with gcc
-
-build --per_file_copt=third_party/.*,external/.*@-Wno-all
-build --per_file_copt=third_party/.*,external/.*@-Wno-extra
-build --per_file_copt=third_party/.*,external/.*@-Wno-shadow
-build --per_file_copt=third_party/.*,external/.*@-Wno-non-virtual-dtor
-build --per_file_copt=third_party/.*,external/.*@-Wno-old-style-cast
-build --per_file_copt=third_party/.*,external/.*@-Wno-cast-align
-build --per_file_copt=third_party/.*,external/.*@-Wno-unused
-build --per_file_copt=third_party/.*,external/.*@-Wno-overloaded-virtual
-build --per_file_copt=third_party/.*,external/.*@-Wno-pedantic
-build --per_file_copt=third_party/.*,external/.*@-Wno-conversion
-build --per_file_copt=third_party/.*,external/.*@-Wno-sign-conversion
-build --per_file_copt=third_party/.*,external/.*@-Wno-misleading-indentation
-build --per_file_copt=third_party/.*,external/.*@-Wno-duplicated-cond
-build --per_file_copt=third_party/.*,external/.*@-Wno-duplicated-branches
-build --per_file_copt=third_party/.*,external/.*@-Wno-logical-op
-build --per_file_copt=third_party/.*,external/.*@-Wno-null-dereference
-build --per_file_copt=third_party/.*,external/.*@-Wno-useless-cast
-build --per_file_copt=third_party/.*,external/.*@-Wno-double-promotion
-build --per_file_copt=third_party/.*,external/.*@-Wno-implicit-fallthrough
+# Disable warnings about C++98 incompatibility. We're using C++17 features...
+build --cxxopt=-Wno-c++98-compat
+build --cxxopt=-Wno-c++98-compat-pedantic
+# Disable warnings for external libs
+build --per_file_copt=third_party/.*,external/.*@-Wno-everything
 build --per_file_copt=third_party/.*,external/.*@-Wno-error
-# build --per_file_copt=third_party/.*,external/.*@-Wno-lifetime # incompatible with gcc

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,3 @@
 Checks: 'clang-analyzer-*,bugprone-*,modernize-*,readability-*,cppcoreguidelines-*,performance-*,concurrency-*,cert-*,google-*,misc-*'
 WarningsAsErrors: '*'
-HeaderFilterRegex: '.*'
+HeaderFilterRegex: '^(?!.*(third_party|external)).*'

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -20,22 +20,13 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y clang-tidy
-
-    - name: Generate compile commands json file
-      run: |
-        bazel run @hedron_compile_commands//:refresh_all
-
     - name: Run Clang-Tidy
       run: |
-        files=$(find . -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cxx" -o -name "*.hxx" )
-
-        echo -e "Running clang-tidy on the following files: \n$files"
-        clang-tidy --version
-        echo "$files" | xargs clang-tidy -p ./compile_commands.json
+        echo -e "Running clang-tidy"
+        bazel build //... \
+        --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect \
+        --output_groups=report \
+        --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
 
     - name: Show failure message
       if: failure()

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -25,16 +25,25 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y clang-tidy
 
+    - name: Generate compile commands json file
+      run: |
+        bazel run @hedron_compile_commands//:refresh_all
+
     - name: Run Clang-Tidy
       run: |
-        files=$(find . \( -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cxx" -o -name "*.hxx" \) -not -name "test*.cpp")
+        files=$(find . -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cxx" -o -name "*.hxx" )
 
-        echo "Files to analyze: $files"
-        echo "Running clang tidy"
-        echo "$files" | xargs clang-tidy
+        echo -e "Running clang-tidy on the following files: \n$files"
+        clang-tidy --version
+        echo "$files" | xargs clang-tidy -p ./compile_commands.json
 
     - name: Show failure message
       if: failure()
       run: |
         echo -e "To automatically apply suggested fixes, run the following command:
-        find . \( -name \"*.cpp\" -o -name \"*.h\" -o -name \"*.hpp\" -o -name \"*.cc\" -o -name \"*.cxx\" -o -name \"*.hxx\" \) -not -name \"test*.cpp\" | xargs clang-tidy -fix -fix-errors"
+        ======================================================================================
+        1. Generate compile commands:
+        bazel run @hedron_compile_commands//:refresh_all
+        2. Run clang-tidy:
+        find . -name \"*.cpp\" -o -name \"*.h\" -o -name \"*.hpp\" -o -name \"*.cc\" -o -name \"*.cxx\" -o -name \"*.hxx\" | xargs clang-tidy -fix -fix-errors -p ./compile_commands.json
+        ======================================================================================"

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,7 @@
+filegroup(
+    name = "clang_tidy_config",
+    srcs = [
+        ".clang-tidy",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,1 +1,10 @@
 bazel_dep(name = "googletest", version = "1.15.2")
+
+# Hedron's Compile Commands Extractor for Bazel
+# https://github.com/hedronvision/bazel-compile-commands-extractor
+bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
+git_override(
+    module_name = "hedron_compile_commands",
+    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
+    commit = "4f28899228fb3ad0126897876f147ca15026151e",
+)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,58 @@
 # SEAME-Course-24-25
-SEAME repository for the course
+
+## Table of Contents
+
+1. [Tooling](#1-tooling)
+   - [Clang-Tidy](#11-clang-tidy)
+     - [Clang-Tidy Analysis](#12-clang-tidy-analysis)
+     - [Automatic Fixes Locally](#13-automatic-fixes-locally)
+
+---
+
+## 1. Tooling
+
+### 1.1. Clang-Tidy
+
+Clang-Tidy is a static analysis tool for C++ code. It helps identify potential issues, enforce coding standards, and suggest improvements to your code. This section describes how to integrate and use Clang-Tidy with your project for both analysis and automatic fixes.
+
+---
+
+### 1.2. Clang-Tidy Analysis
+
+To run Clang-Tidy analysis on your codebase using Bazel, execute the following command:
+
+```bash
+bazel build //... \
+  --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect \
+  --output_groups=report \
+  --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config
+```
+
+The checks are define on .clang-tidy file.
+
+### 1.3. Automatic Fixes Locally
+
+To automatically apply fixes suggested by Clang-Tidy, follow these steps:
+
+1. Generate compile_commands.json:
+
+    This file contains the necessary compilation information for Clang-Tidy to analyze your project files. Run the following command to generate it:
+
+    ```bash
+    bazel run @hedron_compile_commands//:refresh_all
+    ```
+
+    This ensures that the compile_commands.json file is up-to-date and reflects the latest build settings.
+
+2. Run Clang-Tidy with the -fix option:
+
+    Now, you can apply Clang-Tidy fixes by running the following command:
+
+    ```bash
+    find . -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cxx" -o -name "*.hxx" | xargs clang-tidy --header-filter=".*" -p ./compile_commands.json
+    ```
+
+    This command:
+    Finds all relevant C++ source files in the project.
+    Runs Clang-Tidy on each file using the compile_commands.json for accurate analysis.
+    Applies any fixes Clang-Tidy suggests (e.g., code style corrections, best practice recommendations).

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,10 @@
+load(
+    "@bazel_tools//tools/build_defs/repo:git.bzl",
+    "git_repository",
+)
+
+git_repository(
+       name = "bazel_clang_tidy",
+       commit = "bff5c59c843221b05ef0e37cef089ecc9d24e7da",
+       remote = "https://github.com/erenon/bazel_clang_tidy.git",
+)

--- a/examples/cpp/hello.hpp
+++ b/examples/cpp/hello.hpp
@@ -1,9 +1,4 @@
-#ifndef MAIN_HELLO_GREET_H_
-#define MAIN_HELLO_GREET_H_
-
 #include <string>
 
 auto greet() -> std::string;
 auto farewell() -> std::string;
-
-#endif

--- a/examples/cpp/test.cpp
+++ b/examples/cpp/test.cpp
@@ -1,6 +1,9 @@
 #include <gtest/gtest.h>
 #include "hello.hpp"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wglobal-constructors"
 TEST(HelloWorldTest, GreetTest) {
+#pragma GCC diagnostic pop
     EXPECT_EQ(greet(), "Hello World!");
 }


### PR DESCRIPTION
A compile commands file can be used so that clang tidy has access to the information related to the build.
With this approach, clang-tidy can solve the includes of the external dependencies, such as qt or gtest.
The compiler was changed to clang, so that the warning options would be compatible with clang-tidy.
The C++ version was defined as 20. gtest is incompatible with C++23.

Issue: https://github.com/SEAME-pt/jet_racers/issues/29