### PR TITLE
ci: make bazel buildifier job incremental

### DIFF
--- a/.github/workflows/bazel_buildifier.yml
+++ b/.github/workflows/bazel_buildifier.yml
@@ -1,9 +1,9 @@
+# yamllint disable rule:line-length
 ---
 name: Bazel Buildifier
 on:  # yamllint disable-line rule:truthy
   pull_request:
     branches: ['*']
-    paths: [BUILD, WORKSPACE, MODULE.bazel, .bazelrc]
 jobs:
   bazel_buildifier:
     runs-on: ubuntu-latest
@@ -21,9 +21,21 @@ jobs:
             ${{ runner.os }}-${{ env.cache-name }}-development
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Get changed files
+        uses: jitterbit/get-changed-files@v1
+        id: changed_files
+        with:
+          format: space-delimited
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Buildifier
         run: |-
-          bazel run //bazel:buildifier_check
+          echo "${{ steps.changed_files.outputs.all }}"
+          if echo "${{ steps.changed_files.outputs.all }}" | grep -qE '(BUILD|WORKSPACE|MODULE\.bazel|\.bazelrc)$'; then
+            echo "Running bazel buildifier"
+            bazel run //bazel:buildifier_check
+          else
+            echo -e "Skipping bazel buildifier since no bazel files were changed."
+          fi
       - name: Fail message
         if: failure()
         run: |-


### PR DESCRIPTION
Run buildifier only if bazel files where changed, else report as success.
Required for blocking merges.

Issue: https://github.com/SEAME-pt/jet_racers/issues/38
