### PR TITLE
ci: add clang-format workflow

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 100

--- a/.github/workflows/clang_format.yml
+++ b/.github/workflows/clang_format.yml
@@ -1,0 +1,39 @@
+# yamllint disable rule:line-length
+---
+name: Clang-Format
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches: ['*']
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Get changed files
+        uses: jitterbit/get-changed-files@v1
+        id: changed_files
+        with:
+          format: space-delimited
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up clang-format
+        run: sudo apt-get install clang-format
+      - name: Run clang-format
+        run: |
+          if echo "${{ steps.changed_files.outputs.all }}" | grep -qE '\.(cpp|h|hpp|cc|cxx|hxx)$'; then
+              echo -e "Running clang-format"
+              find . -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cxx" -o -name "*.hxx" | xargs clang-format --dry-run --Werror
+          else
+              echo -e "Skipping clang-format since no source files were changed."
+          fi
+      - name: Show failure message
+        if: failure()
+        run: |-
+          echo -e "To automatically apply suggested fixes, run the following command:
+          ======================================================================================
+          1. Install clang-format:
+          sudo apt-get install clang-format
+          2. Run clang-format:
+          find . -name \"*.cpp\" -o -name \"*.h\" -o -name \"*.hpp\" -o -name \"*.cc\" -o -name \"*.cxx\" -o -name \"*.hxx\" | xargs clang-format -i
+          ======================================================================================"

--- a/examples/cpp/hello.cpp
+++ b/examples/cpp/hello.cpp
@@ -1,10 +1,7 @@
 #include "hello.hpp"
+
 #include <string>
 
-auto greet() -> std::string {
-    return "Hello World!";
-}
+auto greet() -> std::string { return "Hello World!"; }
 
-auto farewell() -> std::string {
-    return "Bye World!";
-}
+auto farewell() -> std::string { return "Bye World!"; }

--- a/examples/cpp/main.cpp
+++ b/examples/cpp/main.cpp
@@ -1,7 +1,8 @@
-#include "hello.hpp"
 #include <iostream>
 
-auto main(int  /*argc*/, char**  /*argv*/) -> int {
-  std::cout << greet() << '\n';
-  return 0;
+#include "hello.hpp"
+
+auto main(int /*argc*/, char** /*argv*/) -> int {
+    std::cout << greet() << '\n';
+    return 0;
 }

--- a/examples/cpp/test.cpp
+++ b/examples/cpp/test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+
 #include "hello.hpp"
 
 #pragma GCC diagnostic push

--- a/examples/qt/hello.cpp
+++ b/examples/qt/hello.cpp
@@ -1,7 +1,9 @@
 #include "hello.hpp"
+
+#include <qlabel.h>
+
 #include <QLabel>
 #include <memory>
-#include <qlabel.h>
 
 MyWidget::MyWidget() {
     constexpr int LabelXPos = 100;

--- a/examples/qt/hello.hpp
+++ b/examples/qt/hello.hpp
@@ -1,9 +1,9 @@
 #include <qwidget.h>
+
 #include <QWidget>
 
-class MyWidget : public QWidget
-{
-public:
+class MyWidget : public QWidget {
+   public:
     MyWidget();
     ~MyWidget() override;
     MyWidget(const MyWidget&) = delete;

--- a/examples/qt/main.cpp
+++ b/examples/qt/main.cpp
@@ -1,7 +1,9 @@
-#include "hello.hpp"
-#include <QApplication>
 #include <qapplication.h>
+
+#include <QApplication>
 #include <memory>
+
+#include "hello.hpp"
 
 auto main(int argc, char **argv) -> int {
     QApplication const app(argc, argv);


### PR DESCRIPTION
clang-format is configured accordingly to the .clang-format file.
More options can be added to the .clang-format file in a follow-up.

Issue: https://github.com/SEAME-pt/jet_racers/issues/36