### PR TITLE
ci: fix condition in buildifier workflow

### DIFF
--- a/.github/workflows/bazel_buildifier.yml
+++ b/.github/workflows/bazel_buildifier.yml
@@ -32,7 +32,7 @@ jobs:
           IFS=' ' read -r -a files <<< "${{ steps.changed_files.outputs.all }}"
           bazel_files=()
           for file in "${files[@]}"; do
-              if [[ "$file" == BUILD || "$file" == WORKSPACE || "$file" == MODULE\.bazel || "$file" == \.bazelrc ]]; then
+              if [[ "$file" == *BUILD || "$file" == *WORKSPACE || "$file" == *MODULE.bazel || "$file" == *.bazelrc ]]; then
                   bazel_files+=("$file")
               fi
           done


### PR DESCRIPTION
The file variable contains the full path so matching with `*`

Issue: https://github.com/SEAME-pt/jet_racers/issues/43
