### PR TITLE
tool: change default warning options

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,12 +3,46 @@ build --verbose_failures
 build --repo_env=CC=clang
 build --cxxopt=-std=c++20
 
-# Warning options follow https://github.com/cpp-best-practices/cppbestpractices/blob/master/02-Use_the_Tools_Available.md#gcc%E2%80%94clang
-build --cxxopt=-Weverything # incompatible with gcc
+# Non-critical (Default)
+
+build --cxxopt=-Wall
+build --cxxopt=-Wextra
+build --cxxopt=-Wpedantic
+build --cxxopt=-Wshadow
+build --cxxopt=-Wnon-virtual-dtor
+build --cxxopt=-Wold-style-cast
+build --cxxopt=-Wcast-align
+build --cxxopt=-Wunused
+build --cxxopt=-Woverloaded-virtual
+build --cxxopt=-Wconversion
+build --cxxopt=-Wsign-conversion
+build --cxxopt=-Wmisleading-indentation
+build --cxxopt=-Wnull-dereference
+build --cxxopt=-Wformat=2
+build --cxxopt=-Wimplicit-fallthrough
 build --cxxopt=-Werror
-# Disable warnings about C++98 incompatibility. We're using C++17 features...
-build --cxxopt=-Wno-c++98-compat
-build --cxxopt=-Wno-c++98-compat-pedantic
-# Disable warnings for external libs
+
+# Disable warning option for external libs
+
+build --per_file_copt=third_party/.*,external/.*@-Wno-all
+build --per_file_copt=third_party/.*,external/.*@-Wno-extra
+build --per_file_copt=third_party/.*,external/.*@-Wno-pedantic
+build --per_file_copt=third_party/.*,external/.*@-Wno-shadow
+build --per_file_copt=third_party/.*,external/.*@-Wno-non-virtual-dtor
+build --per_file_copt=third_party/.*,external/.*@-Wno-old-style-cast
+build --per_file_copt=third_party/.*,external/.*@-Wno-cast-align
+build --per_file_copt=third_party/.*,external/.*@-Wno-unused
+build --per_file_copt=third_party/.*,external/.*@-Wno-overloaded-virtual
+build --per_file_copt=third_party/.*,external/.*@-Wno-conversion
+build --per_file_copt=third_party/.*,external/.*@-Wno-sign-conversion
+build --per_file_copt=third_party/.*,external/.*@-Wno-misleading-indentation
+build --per_file_copt=third_party/.*,external/.*@-Wno-null-dereference
+build --per_file_copt=third_party/.*,external/.*@-Wno-format=2
+build --per_file_copt=third_party/.*,external/.*@-Wno-implicit-fallthrough
 build --per_file_copt=third_party/.*,external/.*@-Wno-everything
 build --per_file_copt=third_party/.*,external/.*@-Wno-error
+
+# Disable warnings incompatible with C++20
+
+build --cxxopt=-Wno-c++98-compat
+build --cxxopt=-Wno-c++98-compat-pedantic

--- a/README.md
+++ b/README.md
@@ -5,35 +5,43 @@
 - [1. Tooling](#1-tooling)
   - [1.1. Bazel](#11-bazel)
     - [Setup](#111-setup)
-    - [Test Run](#112-test-run)
-  - [1.2. Clang-Tidy](#12-clang-tidy)
-    - [Clang-Tidy Analysis](#121-clang-tidy-analysis)
-    - [Automatic Fixes Locally](#122-automatic-fixes-locally)
-  - [1.3. Clang-Format](#13-clang-format)
-    - [Clang-Format Analysis](#131-clang-format-analysis)
-    - [Automatic Fixes Locally](#132-automatic-fixes-locally)
-  - [1.4. Bazel Buildifier](#14-bazel-buildifier)
-    - [How to Run](#141-how-to-run)
+  - [1.2. Compiler](#12-compiler)
+  - [1.3. Clang-Tidy](#13-clang-tidy)
+    - [Run Analysis](#131-run-analysis)
+    - [Apply Fixes](#132-apply-fixes)
+  - [1.4. Clang-Format](#14-clang-format)
+    - [Run Analysis](#141-run-analysis)
+    - [Apply Fixes](#142-apply-fixes)
+  - [1.5. Bazel Buildifier](#15-bazel-buildifier)
+    - [How to Run](#151-how-to-run)
 
 # 1. Tooling
 
 ## 1.1. Bazel
 
-## 1.1.1 Setup
+Bazel is a powerful, fast, and extensible build system.
 
-Follow step 1 and 2 of bazel documentation: <https://bazel.build/install/ubuntu>
+### 1.1.1 Setup
 
-## 1.1.2 Run Hello World
+To get started, follow steps 1 and 2 of the official [Bazel installation guide](https://bazel.build/install/ubuntu).
+
+Once Bazel is installed, you can run a simple "Hello World" example by executing the following command:
 
 ```bash
 bazel run //examples/cpp:bin
 ```
 
-## 1.2. Clang-Tidy
+This will build and run the bin target from the examples/cpp directory.
+
+## 1.2. Compiler
+
+The build settings, such as the choice of compiler, the C++ standard version, and default warning options, are configured in the `.bazelrc` file. In this setup, the compiler is set to Clang, and the C++ standard version is defined as C++20.
+
+## 1.3. Clang-Tidy
 
 Clang-Tidy is a static analysis tool for C++ code. It helps identify potential issues, enforce coding standards, and suggest improvements to your code. This section describes how to integrate and use Clang-Tidy with your project for both analysis and automatic fixes.
 
-### 1.2.1. Clang-Tidy Analysis
+### 1.3.1. Run Analysis
 
 To run Clang-Tidy analysis on your codebase using Bazel, execute the following command:
 
@@ -46,7 +54,7 @@ bazel build //... \
 
 The checks are define on .clang-tidy file.
 
-### 1.2.2. Automatic Fixes Locally
+### 1.3.2. Apply Fixes
 
 To automatically apply fixes suggested by Clang-Tidy, follow these steps:
 
@@ -73,11 +81,11 @@ To automatically apply fixes suggested by Clang-Tidy, follow these steps:
     Runs Clang-Tidy on each file using the compile_commands.json for accurate analysis.
     Applies any fixes Clang-Tidy suggests (e.g., code style corrections, best practice recommendations).
 
-## 1.3. Clang-Format
+## 1.4. Clang-Format
 
 Clang-Format is a tool that automatically formats C++ source code according to a set of predefined or custom style rules. Below are instructions for running Clang-Format analysis and applying automatic fixes to your code locally.
 
-### 1.3.1. Clang-Format Analysis
+### 1.4.1. Run Analysis
 
 To check the formatting of your code without making any changes, use the following command. It will run `clang-format` in "dry-run" mode, which simulates formatting and reports any issues without modifying files.
 
@@ -89,7 +97,7 @@ find . -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*
 - `-name` "*.cpp" -o -name "*.h" ... ensures all common C++ file extensions are included.
 - `xargs clang-format --dry-run --Werror` applies clang-format to the found files, in "dry-run" mode (no changes are made), and treats any formatting violations as errors (--Werror).
 
-### 1.3.2. Automatic Fixes Locally
+### 1.4.2. Apply Fixes
 
 To automatically fix the formatting of your code based on the predefined style, you can use the following command. It will rewrite the files in-place according to Clang-Format's rules.
 
@@ -97,9 +105,9 @@ To automatically fix the formatting of your code based on the predefined style, 
 find . -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cxx" -o -name "*.hxx" | xargs clang-format -i
 ```
 
-## 1.4. Bazel Buildifier
+## 1.5. Bazel Buildifier
 
-### 1.4.1. How to Run
+### 1.5.1. How to Run
 
 `Buildifier` is a tool for formatting Bazel build files (e.g., `BUILD`, `WORKSPACE`). It automatically reformats these files according to a consistent style, improving readability and maintaining consistency across your project.
 

--- a/examples/cpp/BUILD
+++ b/examples/cpp/BUILD
@@ -7,6 +7,9 @@ cc_library(
 cc_binary(
     name = "bin",
     srcs = ["main.cpp"],
+    copts = [
+        "-Weverything",  # critical
+    ],
     deps = [
         ":lib",
     ],


### PR DESCRIPTION
## Description

Non-critical code doesn't need to comply with `-Weverything`.
Default options changed.

## Checklist

- [x] Code follows project style guidelines.
- [x] Tests added or updated.
- [x] Documentation updated (if applicable).

## Testing

Build workflow.

## Related Issue

Issue: https://github.com/SEAME-pt/jet_racers/issues/38

