### PR TITLE
ci: extend pattern in github action to check github description

### DIFF
--- a/.github/workflows/check_pr_description.yml
+++ b/.github/workflows/check_pr_description.yml
@@ -10,15 +10,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Check PR description for 'Issue:' link
+      - name: Check PR description for issue link
         id: contains_issue
         run: |
           PR_BODY=$(curl -s https://api.github.com/repos/${{
             github.repository }}/pulls/${{ github.event.pull_request.number }} | jq -r .body)
           echo "$PR_BODY"
-          pattern="https://github\.com/([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)/issues/([0-9]+)"
-          if [[ ! "$PR_BODY" =~ $pattern ]]; then
-            echo "Error: PR description must include an issue link in the format 'Issue:  # 123' or 'Issue: https://github.com/owner/repo/issues/123'." >&2
+          pattern_1="https://github\.com/([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)/issues/([0-9]+)"
+          pattern_2="#([0-9]+)"
+          pattern_3="[#([0-9]+)]"
+          if [[ ! "$PR_BODY" =~ $pattern_1 ]] && [[ ! "$PR_BODY" =~ $pattern_2 ]] && [[ ! "$PR_BODY" =~ $pattern_3 ]]; then
+            echo "Error: PR description must include an issue link in the format '#123' or 'https://github.com/owner/repo/issues/123'." >&2
             exit 1
           else
             echo "PR description contains a valid issue link."
@@ -26,4 +28,4 @@ jobs:
       - name: Fail PR if no issue link found
         if: failure()
         run: |-
-          echo "Please add an issue link in the format 'Issue: # 123' or 'Issue: https://github.com/owner/repo/issues/123' in the PR description."
+          echo "Please add an issue link in the format '#123' or 'https://github.com/owner/repo/issues/123' in the PR description."


### PR DESCRIPTION
## Description

Extend pattern to also allow to linking issues that start with `#`.

## Checklist

- [x] Code follows project style guidelines.

## Testing

Running action in CI.

## Related Issue

[#38](https://github.com/SEAME-pt/jet_racers/issues/38)