### PR TITLE
ci: run arduino-lint recursively across the arduino directory

### DIFF
--- a/.github/workflows/arduino_lint.yml
+++ b/.github/workflows/arduino_lint.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Run arduino-lint
         if: env.ino_files != ''
         run: |
-          echo "Running: arduino-lint ./arduino"
-          arduino-lint ./arduino
+          echo "Running: arduino-lint"
+          arduino-lint --recursive ./arduino
 
       - name: Skip arduino-lint
         if: env.ino_files == ''


### PR DESCRIPTION
## Description

Fix for arduino linter action, by adding `--recursive` option.

## Checklist

- [x] Code follows project style guidelines.

## Testing

Tested on the CI.

## Related Issue

Issue: https://github.com/SEAME-pt/jet_racers/issues/38