### PR TITLE
toolchain: update to qt6 [WIP]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,93 @@
+# Base image
 FROM ubuntu:22.04
 
+# Variables
+ENV HOME=/root
+ENV PATH="$HOME/bin:$HOME/usr/bin:$PATH"
+ARG QT_MAJOR_VERSION="6.8"
+ARG QT_MINOR_VERSION="6.8.1"
+
+# Install required dependencies
 RUN apt-get update && apt-get install -y \
-    build-essential \
     vim \
-    git \
     curl \
-    wget \
-    python3 \
-    python3-pip \
-    cmake \
     lcov \
     file \
-    mesa-common-dev \
-    mesa-utils \
-    libvulkan-dev \
-    libxkbcommon-x11-0 \
+    python3-pip \
+    wget \
+    git \
+    build-essential \
+    make \
+    cmake \
+    rsync \
+    sed \
+    libclang-dev \
+    ninja-build \
+    gcc \
+    bison \
+    python3 \
+    gperf \
+    pkg-config \
+    libfontconfig1-dev \
+    libfreetype6-dev \
+    libx11-dev \
+    libx11-xcb-dev \
+    libxext-dev \
+    libxfixes-dev \
+    libxi-dev \
+    libxrender-dev \
+    libxcb1-dev \
+    libxcb-glx0-dev \
+    libxcb-keysyms1-dev \
+    libxcb-image0-dev \
+    libxcb-shm0-dev \
+    libxcb-icccm4-dev \
+    libxcb-sync-dev \
+    libxcb-xfixes0-dev \
+    libxcb-shape0-dev \
+    libxcb-randr0-dev \
+    libxcb-render-util0-dev \
+    libxcb-util-dev \
+    libxcb-xinerama0-dev \
+    libxcb-xkb-dev \
     libxkbcommon-dev \
-    software-properties-common \
+    libxkbcommon-x11-dev \
+    libatspi2.0-dev \
     libgl1-mesa-dev \
+    libglu1-mesa-dev \
+    freeglut3-dev \
+    libssl-dev \
+    libgmp-dev \
+    libmpfr-dev \
+    libmpc-dev \
+    flex \
+    gawk \
+    texinfo \
+    libisl-dev \
+    zlib1g-dev \
+    libtool \
+    autoconf \
+    automake \
+    libgdbm-dev \
+    libdb-dev \
+    libbz2-dev \
+    libreadline-dev \
+    libexpat1-dev \
+    liblzma-dev \
+    libffi-dev \
+    libsqlite3-dev \
+    libbsd-dev \
+    perl \
+    patch \
+    m4 \
+    libncurses5-dev \
+    gettext \
+    gcc-aarch64-linux-gnu \
+    g++-aarch64-linux-gnu \
+    binutils-aarch64-linux-gnu \
+    libc6-arm64-cross \
+    libc6-dev-arm64-cross \
+    software-properties-common \
     libxcb-xinerama0 \
     libxcb-xinput0 \
     libxcb-icccm4 \
@@ -31,75 +101,112 @@ RUN apt-get update && apt-get install -y \
     libxcb-xkb1 \
     libxcb-cursor0 \
     locales \
-    qtbase5-dev  \
-    && apt-get clean
+    glibc-source && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
-    && echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" | tee -a /etc/apt/sources.list.d/llvm.list
+# Set git safe directory
+RUN git config --global --add safe.directory /Team04
 
-RUN apt-get update && apt-get install -y \
-    llvm-18 \
-    llvm-18-dev \
-    clang-18 \
-    clang-tools-18 \
-    clang-format-18 \
-    clang-tidy-18 \
-    lld-18 \
-    lldb-18
+# Add LLVM repo and install LLVM tools
+RUN wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
+    echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" | tee -a /etc/apt/sources.list.d/llvm.list && \
+    apt-get update && apt-get install -y \
+        llvm-18 \
+        llvm-18-dev \
+        clang-18 \
+        clang-tools-18 \
+        clang-format-18 \
+        clang-tidy-18 \
+        lld-18 \
+        lldb-18 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Cross-compilation
-RUN apt-get install -y \
-    gcc-aarch64-linux-gnu \
-    g++-aarch64-linux-gnu
+# Set up clang tools alternatives
+RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-18 100 && \
+    update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-18 100 && \
+    update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-18 100 && \
+    update-alternatives --install /usr/bin/llvm-profdata llvm-profdata /usr/bin/llvm-profdata-18 100
 
-RUN pip install yamllint
-
-RUN pip install gitlint
-
-RUN curl -fsSL https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/install.sh | sh
-
-# Download and extract precompiled Qt aarch64 libs
-ENV RELEASE_URL=https://github.com/parker-int64/qt-aarch64-binary/releases/download/5.15.5
-RUN wget ${RELEASE_URL}/qt-5.15.5-aarch64-native-compile-gcc-5.tar.gz -O /tmp/qt-aarch64-binary.tar.gz && \
-    mkdir -p /opt/qt && \
-    tar -xzf /tmp/qt-aarch64-binary.tar.gz -C /opt/qt
-
-RUN rm /tmp/qt-aarch64-binary.tar.gz && \
-    cp -r /opt/qt/qt-5.15.5/lib/* /usr/lib/aarch64-linux-gnu && \
-    mkdir -p /usr/lib/aarch64-linux-gnu/qt5 && \
-    cp -r /opt/qt/qt-5.15.5/* /usr/lib/aarch64-linux-gnu/qt5 && \
-    mkdir -p /usr/include/aarch64-linux-gnu/qt5 && \
-    cp -r /opt/qt/qt-5.15.5/include/* /usr/include/aarch64-linux-gnu/qt5
-
-RUN cp /usr/aarch64-linux-gnu/lib/* /lib/aarch64-linux-gnu && \
-    cp /usr/aarch64-linux-gnu/lib/ld-linux-aarch64.so.1 /lib
-
-# RUN export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/aarch64-linux-gnu
-
-RUN cp /usr/aarch64-linux-gnu/lib/* /lib/aarch64-linux-gnu && \
-    cp /usr/aarch64-linux-gnu/lib/ld-linux-aarch64.so.1 /lib
-
+# Install Bazelisk
 RUN wget https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 && \
     chmod 755 bazelisk-linux-amd64 && \
     mv bazelisk-linux-amd64 /usr/bin/bazelisk
 
-RUN wget https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 && \
-    chmod 755 bazelisk-linux-amd64 && \
-    mv bazelisk-linux-amd64 /usr/bin/bazelisk
-
-ENV HOME=/root
-
-RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-18 100
-
-RUN update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-18 100
-
-RUN update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-18 100
-
-RUN update-alternatives --install /usr/bin/llvm-profdata llvm-profdata /usr/bin/llvm-profdata-18 100
-
+# Set up aliases
 RUN echo "alias bazel='bazelisk'" >> $HOME/.bashrc
+
+# Install linters
+RUN curl -fsSL https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/install.sh | sh && \
+    pip install yamllint gitlint
+
+# Create required directories for Qt
+RUN mkdir -p /build/sysroot /build/qt6/src /build/qt6/host /build/qt6/pi /opt/qt6/host /opt/qt6/pi
+
+# Download the sysroot .tar file from Google Drive
+RUN pip install gdown
+RUN gdown 1EUZuWxTBTHegJAKcGsPDVEAZaag0pa3_ -O /build/rasp.tar.gz
+
+# Copy files to build Qt for aarch64
+RUN tar xvfz /build/rasp.tar.gz -C /build/sysroot
+COPY tools/cross_compilation/qt/toolchain.cmake /build/qt6
+
+# Fix symbolic links in the sysroot
+RUN wget -q https://raw.githubusercontent.com/riscv/riscv-poky/master/scripts/sysroot-relativelinks.py && \
+    chmod +x sysroot-relativelinks.py && \
+    python3 sysroot-relativelinks.py /build/sysroot && \
+    rm -f sysroot-relativelinks.py
+
+# Download and extract Qt source on /build/qt/src
+RUN cd /build/qt6/src && \
+    wget -q https://download.qt.io/official_releases/qt/${QT_MAJOR_VERSION}/${QT_MINOR_VERSION}/submodules/qtbase-everywhere-src-${QT_MINOR_VERSION}.tar.xz && \
+    tar xf qtbase-everywhere-src-${QT_MINOR_VERSION}.tar.xz && \
+    rm qtbase-everywhere-src-${QT_MINOR_VERSION}.tar.xz
+
+# Install Qt for host on /opt/qt6/host and store build files on /build/qt6/host
+RUN cd /build/qt6/host && \
+    cmake /build/qt6/src/qtbase-everywhere-src-${QT_MINOR_VERSION} \
+        -GNinja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DQT_BUILD_EXAMPLES=OFF \
+        -DQT_BUILD_TESTS=OFF \
+        -DCMAKE_INSTALL_PREFIX=/opt/qt6/host && \
+    cmake --build . --parallel 4 && \
+    cmake --install .
+
+# Install Qt for Raspberry Pi on /opt/qt6/pi and store build files on /build/qt6/pi
+RUN cd /build/qt6/pi && \
+    cmake /build/qt6/src/qtbase-everywhere-src-${QT_MINOR_VERSION} \
+        -GNinja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DINPUT_opengl=es2 \
+        -DQT_BUILD_EXAMPLES=OFF \
+        -DQT_BUILD_TESTS=OFF \
+        -DQT_HOST_PATH=/opt/qt6/host \
+        -DCMAKE_STAGING_PREFIX=/opt/qt6/pi \
+        -DCMAKE_INSTALL_PREFIX=/usr/local/qt6 \
+        -DCMAKE_TOOLCHAIN_FILE=/build/qt6/toolchain.cmake \
+        -DQT_QMAKE_TARGET_MKSPEC=devices/linux-rasp-pi4-aarch64 \
+        -DQT_FEATURE_xcb=ON \
+        -DFEATURE_xcb_xlib=ON \
+        -DQT_FEATURE_xlib=ON && \
+    cmake --build . --parallel 4 && \
+    cmake --install .
+
+# Move Qt host binaries, headers, and libs
+RUN mkdir -p /usr/include/x86_64-linux-gnu/qt6 && \
+    cp -r /opt/qt6/host/include/* /usr/include/x86_64-linux-gnu/qt6 && \
+    cp -r /opt/qt6/host/lib/* /usr/lib/x86_64-linux-gnu
+
+# Move Qt target binaries, headers, and libs
+RUN mkdir -p /usr/include/aarch64-linux-gnu/qt6 && \
+    mkdir -p /usr/lib/aarch64-linux-gnu && \
+    cp -r /opt/qt6/pi/include/* /usr/include/aarch64-linux-gnu/qt6 && \
+    cp -r /opt/qt6/pi/lib/* /usr/lib/aarch64-linux-gnu
+
+# Move target binaries, headers, and libs
+RUN cp -r /usr/aarch64-linux-gnu/lib/* /lib/aarch64-linux-gnu && \
+    cp -r /usr/aarch64-linux-gnu/lib/ld-linux-aarch64.so.1 /lib
 
 RUN echo 'if [ -d "$HOME/bin" ] ; then\n    PATH="$HOME/bin:$PATH"\nfi' >> $HOME/.bashrc && \
     echo 'if [ -d "$HOME/usr/bin" ] ; then\n    PATH="$HOME/usr/bin:$PATH"\nfi' >> $HOME/.bashrc
-
-RUN git config --global --add safe.directory /Team04

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,15 +60,28 @@ RUN curl -fsSL https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/i
 
 # Download and extract precompiled Qt aarch64 libs
 ENV RELEASE_URL=https://github.com/parker-int64/qt-aarch64-binary/releases/download/5.15.5
-RUN wget ${RELEASE_URL}/qt-5.15.5-aarch64-cross-compile-gcc-5.tar.gz -O /tmp/qt-aarch64-binary.tar.gz && \
+RUN wget ${RELEASE_URL}/qt-5.15.5-aarch64-native-compile-gcc-5.tar.gz -O /tmp/qt-aarch64-binary.tar.gz && \
     mkdir -p /opt/qt && \
     tar -xzf /tmp/qt-aarch64-binary.tar.gz -C /opt/qt
 
 RUN rm /tmp/qt-aarch64-binary.tar.gz && \
-    mv /opt/qt/qt-5.15.5-aarch64/lib/* /usr/lib/aarch64-linux-gnu
+    cp -r /opt/qt/qt-5.15.5/lib/* /usr/lib/aarch64-linux-gnu && \
+    mkdir -p /usr/lib/aarch64-linux-gnu/qt5 && \
+    cp -r /opt/qt/qt-5.15.5/* /usr/lib/aarch64-linux-gnu/qt5 && \
+    mkdir -p /usr/include/aarch64-linux-gnu/qt5 && \
+    cp -r /opt/qt/qt-5.15.5/include/* /usr/include/aarch64-linux-gnu/qt5
 
 RUN cp /usr/aarch64-linux-gnu/lib/* /lib/aarch64-linux-gnu && \
     cp /usr/aarch64-linux-gnu/lib/ld-linux-aarch64.so.1 /lib
+
+# RUN export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/aarch64-linux-gnu
+
+RUN cp /usr/aarch64-linux-gnu/lib/* /lib/aarch64-linux-gnu && \
+    cp /usr/aarch64-linux-gnu/lib/ld-linux-aarch64.so.1 /lib
+
+RUN wget https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 && \
+    chmod 755 bazelisk-linux-amd64 && \
+    mv bazelisk-linux-amd64 /usr/bin/bazelisk
 
 RUN wget https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 && \
     chmod 755 bazelisk-linux-amd64 && \

--- a/examples/qt/BUILD
+++ b/examples/qt/BUILD
@@ -2,10 +2,10 @@ cc_binary(
     name = "bin",
     srcs = ["main.cpp"],
     copts = [
-        "-I/usr/include/x86_64-linux-gnu/qt5",
-        "-I/usr/include/x86_64-linux-gnu/qt5/QtGui",
-        "-I/usr/include/x86_64-linux-gnu/qt5/QtWidgets",
-        "-I/usr/include/x86_64-linux-gnu/qt5/QtCore",
+        "-I/usr/include/aarch64-linux-gnu/qt5",
+        "-I/usr/include/aarch64-linux-gnu/qt5/QtGui",
+        "-I/usr/include/aarch64-linux-gnu/qt5/QtWidgets",
+        "-I/usr/include/aarch64-linux-gnu/qt5/QtCore",
     ],
     linkopts = [
         "-lQt5Widgets",

--- a/examples/qt/BUILD
+++ b/examples/qt/BUILD
@@ -2,14 +2,14 @@ cc_binary(
     name = "bin",
     srcs = ["main.cpp"],
     copts = [
-        "-I/usr/include/aarch64-linux-gnu/qt5",
-        "-I/usr/include/aarch64-linux-gnu/qt5/QtGui",
-        "-I/usr/include/aarch64-linux-gnu/qt5/QtWidgets",
-        "-I/usr/include/aarch64-linux-gnu/qt5/QtCore",
+        "-I/usr/include/x86_64-linux-gnu/qt6",
+        "-I/usr/include/x86_64-linux-gnu/qt6/QtGui",
+        "-I/usr/include/x86_64-linux-gnu/qt6/QtWidgets",
+        "-I/usr/include/x86_64-linux-gnu/qt6/QtCore",
     ],
     linkopts = [
-        "-lQt5Widgets",
-        "-lQt5Core",
-        "-lQt5Gui",
+        "-lQt6Widgets",
+        "-lQt6Core",
+        "-lQt6Gui",
     ],
 )

--- a/tools/cross_compilation/README.md
+++ b/tools/cross_compilation/README.md
@@ -1,0 +1,26 @@
+# Create Cross-Compilation Sysroot Environment for Raspberry Pi
+
+To build Qt6 from source for aarch64, a cross-compilation sysroot is necessary. This environment allows you to compile software on a host system for ARM-based Raspberry Pi systems.
+
+### Build the Sysroot Locally Using Docker
+
+#### 1. **Ensure Docker is Installed**
+
+Make sure Docker is installed:
+
+```bash
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+```
+
+#### 2. **Run the Setup Script**
+
+Run the setup script to create the sysroot:
+
+```bash
+sudo ./docker/run.sh
+```
+
+### Resources
+
+- [Qt6 Cross-Compilation Guide for Raspberry Pi](https://wiki.qt.io/Cross-Compile_Qt_6_for_Raspberry_Pi)
+- [QTonRaspberryPi GitHub Repository](https://github.com/PhysicsX/QTonRaspberryPi/tree/main)

--- a/tools/cross_compilation/qt/DockerFileRasp
+++ b/tools/cross_compilation/qt/DockerFileRasp
@@ -1,0 +1,46 @@
+# Source: https://github.com/PhysicsX/QTonRaspberryPi/tree/main
+
+# Stage 1: Setting up the environment and copying necessary files from Raspberry Pi OS
+# If you want to choose 32 bit Rasbian then change this line accordingly. Otherwise compilation will fail
+# In this file it is 64 bit -> 2024-07-04-raspios-bookworm-arm64.img
+FROM arm64v8/debian:bookworm
+
+# Avoid interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Create a log file
+RUN touch /build.log
+
+# Update the package list and install necessary packages
+RUN { \
+    echo "deb http://deb.debian.org/debian bookworm main contrib non-free" > /etc/apt/sources.list && \
+    echo "deb-src http://deb.debian.org/debian bookworm main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://security.debian.org/debian-security bookworm-security main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb-src http://security.debian.org/debian-security bookworm-security main contrib non-free" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get full-upgrade -y && \
+    apt-get install -y \
+    libboost-all-dev libudev-dev libinput-dev libts-dev libmtdev-dev \
+    libjpeg-dev libfontconfig1-dev libssl-dev libdbus-1-dev libglib2.0-dev \
+    libxkbcommon-dev libegl1-mesa-dev libgbm-dev libgles2-mesa-dev \
+    mesa-common-dev libasound2-dev libpulse-dev gstreamer1.0-omx \
+    libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-alsa \
+    libvpx-dev libsrtp2-dev libsnappy-dev libnss3-dev "^libxcb.*" \
+    flex bison libxslt-dev libc6-arm64-cross ruby gperf libbz2-dev libcups2-dev \
+    libatkmm-1.6-dev libxi6 libxcomposite1 libfreetype6-dev libicu-dev \
+    libsqlite3-dev libxslt1-dev libavcodec-dev libavformat-dev libswscale-dev \
+    libx11-dev freetds-dev libpq-dev libiodbc2-dev firebird-dev \
+    libxext-dev libxcb1 libxcb1-dev libx11-xcb1 libx11-xcb-dev \
+    libxcb-keysyms1 libxcb-keysyms1-dev libxcb-image0 libxcb-image0-dev \
+    libxcb-shm0 libxcb-shm0-dev libxcb-icccm4 libxcb-icccm4-dev \
+    libxcb-sync1 libxcb-sync-dev libxcb-render-util0 libxcb-render-util0-dev \
+    libxcb-xfixes0-dev libxrender-dev libxcb-shape0-dev libxcb-randr0-dev \
+    libxcb-glx0-dev libxi-dev libdrm-dev libxcb-xinerama0 libxcb-xinerama0-dev \
+    libatspi2.0-dev libxcursor-dev libxcomposite-dev libxdamage-dev \
+    libxss-dev libxtst-dev libpci-dev libcap-dev libxrandr-dev \
+    libdirectfb-dev libaudio-dev libxkbcommon-x11-dev gdbserver; \
+} 2>&1 | tee -a /build.log
+
+WORKDIR /build
+
+RUN tar cvfz rasp.tar.gz -C / lib usr/include usr/lib

--- a/tools/cross_compilation/qt/run.sh
+++ b/tools/cross_compilation/qt/run.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+set -o noglob
+
+CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TAR_FILE="${CURRENT_DIR}/rasp.tar.gz"
+DOCKERFILE="${CURRENT_DIR}/DockerFileRasp"
+IMAGE_NAME="raspimage"
+CONTAINER_NAME="temp-arm"
+
+function log() {
+    echo "[INFO] $1"
+}
+
+function error() {
+    echo "[ERROR] $1" >&2
+    exit 1
+}
+
+function build_and_copy_tar() {
+    log "Building Docker image '${IMAGE_NAME}' for ARM64..."
+    sudo docker buildx build --platform linux/arm64 --load -f "${DOCKERFILE}" -t "${IMAGE_NAME}" .
+
+    log "Creating temporary container '${CONTAINER_NAME}'..."
+    sudo docker create --name "${CONTAINER_NAME}" "${IMAGE_NAME}"
+
+    log "Copying rasp.tar.gz from container to '${CURRENT_DIR}'..."
+    sudo docker cp "${CONTAINER_NAME}:/build/rasp.tar.gz" "${TAR_FILE}"
+
+    log "Cleaning up temporary container..."
+    sudo docker rm -f "${CONTAINER_NAME}" >/dev/null
+}
+
+function main() {
+    if [ ! -f "${TAR_FILE}" ]; then
+        log "File '${TAR_FILE}' does not exist. Starting the build process..."
+        if [ ! -f "${DOCKERFILE}" ]; then
+            error "Dockerfile '${DOCKERFILE}' not found. Please check the path."
+        fi
+        build_and_copy_tar
+        log "File '${TAR_FILE}' has been successfully created."
+    else
+        log "File '${TAR_FILE}' already exists. Skipping the build process."
+    fi
+}
+
+main


### PR DESCRIPTION
## Description

Build Qt6 from source to enable cross-compilation from x86 to aarch64.

- aarch64 sysroot is required. It is possible to build locally, but docker image download the .tar file from google drive.
- Create github action to build for aarch64.

## Checklist

- [ ] Code follows project style guidelines.
- [ ] Tests added or updated.
- [ ] Documentation updated (if applicable).
- [ ] Tested in simulation/real-world environment (if applicable).

## Testing

Tested locally and by github action to build project.

## Related Issue
