### PR TITLE
toolchain: add custom rules for Qt integration

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -43,6 +43,50 @@ jobs:
           echo "cpp_files=$(cat affected_cpp_files.txt | tr -s '\n' ' ' | sed 's/^[ \t]*//;s/[ \t]*$//')" >> $GITHUB_ENV
         shell: bash
 
+      - name: Find affected Bazel targets
+        id: bazel_targets
+        run: |
+          > affected_targets.txt
+
+          while read file; do
+            if [[ "$file" == *.c || "$file" == *.cc || "$file" == *.cpp || "$file" == *.cxx || "$file" == *.h || "$file" == *.hpp || "$file" == *.hxx ]]; then
+              echo "Finding targets for: $file"
+              targets=$(bazelisk query --output=package "$file")/...
+              echo "$targets" >> affected_targets.txt
+            fi
+          done < affected_files.txt
+
+          sort -u affected_targets.txt -o affected_targets.txt
+          echo "Affected targets:"
+          cat affected_targets.txt
+
+          echo "targets=$(cat affected_targets.txt | tr -s '\n' ' ' | sed 's/^[ \t]*//;s/[ \t]*$//')" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Setup bazel cache
+        if: env.targets != ''
+        uses: actions/cache@v4
+        env:
+          cache-name: bazel-cache
+        with:
+          path: |
+            ~/.cache/bazelisk
+            ~/.cache/bazel
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-development
+
+      - name: Build affected targets
+        if: env.targets != ''
+        run: |
+          echo "Building targets: $targets"
+          bazelisk build $targets
+        shell: bash
+
+      - name: No targets to build
+        if: env.targets == ''
+        run: echo "No affected Bazel targets found. Skipping build."
+
       - name: Generate Compile Commands
         if: env.cpp_files != ''
         run: |

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,7 @@
 bazel_dep(name = "googletest", version = "1.15.2")
 bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
-bazel_dep(name = "rules_python", version = "1.0.0")
+bazel_dep(name = "rules_python", version = "1.1.0")
+bazel_dep(name = "rules_cc", version = "0.0.17")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ To automatically apply fixes suggested by Clang-Tidy, follow these steps:
 
     This ensures that the compile_commands.json file is up-to-date and reflects the latest build settings.
 
+    If this command fails, clean the cache with `bazel clean` and delete an existing `build` directory before trying again.
+
 2. Run Clang-Tidy Analysis:
 
     ```bash

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ To automatically apply fixes suggested by Clang-Tidy, follow these steps:
     Use the following command to find all relevant C++ source files in the project.
 
     ```bash
-    find . -iname "*.c" -o -iname "*.cc" -o -iname "*.cpp" -o -iname "*.cxx" -o -iname "*.h" -o -iname "*.hpp" -o -iname "*.hxx"" | xargs clang-tidy -p ./compile_commands.json
+    find . -iname "*.c" -o -iname "*.cc" -o -iname "*.cpp" -o -iname "*.cxx" -o -iname "*.h" -o -iname "*.hpp" -o -iname "*.hxx" | xargs clang-tidy -p ./compile_commands.json
     ```
 
 3. To automatically apply any fixes, use the following commands:

--- a/bazel/rules/qt.bzl
+++ b/bazel/rules/qt.bzl
@@ -14,10 +14,10 @@ QT_INCLUDE_PATHS = select({
         "-I/usr/include/x86_64-linux-gnu/qt5/QtCore",
     ],
     "@platforms//cpu:aarch64": [
-        "-I/usr/include/aarch64-linux-gnu/qt5",
-        "-I/usr/include/aarch64-linux-gnu/qt5/QtGui",
-        "-I/usr/include/aarch64-linux-gnu/qt5/QtWidgets",
-        "-I/usr/include/aarch64-linux-gnu/qt5/QtCore",
+        "-I/usr/include/x86_64-linux-gnu/qt5",
+        "-I/usr/include/x86_64-linux-gnu/qt5/QtGui",
+        "-I/usr/include/x86_64-linux-gnu/qt5/QtWidgets",
+        "-I/usr/include/x86_64-linux-gnu/qt5/QtCore",
     ],
 })
 

--- a/bazel/rules/qt.bzl
+++ b/bazel/rules/qt.bzl
@@ -1,0 +1,168 @@
+"""
+This module provides Bazel rules for working with Qt, including support for generating
+Qt UI headers, processing Qt meta-object compiler (moc) files, and building binaries
+with appropriate Qt library paths.
+"""
+
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
+QT_INCLUDE_PATHS = select({
+    "@platforms//cpu:x86_64": [
+        "-I/usr/include/x86_64-linux-gnu/qt5",
+        "-I/usr/include/x86_64-linux-gnu/qt5/QtGui",
+        "-I/usr/include/x86_64-linux-gnu/qt5/QtWidgets",
+        "-I/usr/include/x86_64-linux-gnu/qt5/QtCore",
+    ],
+    "@platforms//cpu:aarch64": [
+        "-I/usr/include/aarch64-linux-gnu/qt5",
+        "-I/usr/include/aarch64-linux-gnu/qt5/QtGui",
+        "-I/usr/include/aarch64-linux-gnu/qt5/QtWidgets",
+        "-I/usr/include/aarch64-linux-gnu/qt5/QtCore",
+    ],
+})
+
+QT_LINK_PATHS = [
+    "-lQt5Widgets",
+    "-lQt5Core",
+    "-lQt5Gui",
+]
+
+qt_plugin_data = select({
+    "@platforms//cpu:x86_64": ["/usr/lib/x86_64-linux-gnu", "/usr/lib/x86_64-linux-gnu/plugins", "/usr/lib/x86_64-linux-gnu/qml"],
+    "@platforms//cpu:aarch64": ["/usr/lib/aarch64-linux-gnu", "/usr/lib/aarch64-linux-gnu/plugins", "/usr/lib/aarch64-linux-gnu/qml"],
+})
+
+x86_64_env = {
+    "QT_PLUGIN_PATH": "/usr/lib/x86_64-linux-gnu/plugins",
+    "QT_QPA_PLATFORM_PLUGIN_PATH": "/usr/lib/x86_64-linux-gnu/plugins/platforms",
+    "QML2_IMPORT_PATH": "/usr/lib/x86_64-linux-gnu/qml",
+}
+
+aarch64_env = {
+    "QT_PLUGIN_PATH": "/usr/lib/aarch64-linux-gnu/plugins",
+    "QT_QPA_PLATFORM_PLUGIN_PATH": "/usr/lib/aarch64-linux-gnu/plugins/platforms",
+    "QML2_IMPORT_PATH": "/usr/lib/aarch64-linux-gnu/qml",
+}
+
+def update_dict(source, env):
+    result = {}
+    result.update(source)
+    result.update(env)
+    return result
+
+def qt_ui_library(name, ui, deps = None, **kwargs):
+    """
+    Creates a cc_library for a Qt UI file.
+
+    This rule uses the Qt User Interface Compiler (uic) to generate a header file
+    for the provided UI file and packages it as a Bazel `cc_library`.
+
+    Args:
+        name (str): The name of the library.
+        ui (str): The path to the .ui file.
+        deps (list): A list of dependencies for the generated library.
+        **kwargs: Additional keyword arguments for `cc_library`.
+    """
+    native.genrule(
+        name = "%s_uic" % name,
+        srcs = [ui],
+        outs = ["ui_%s.h" % ui.split(".")[0]],
+        cmd = "echo 'Running uic command: uic $(location %s) -o $@' && uic $(location %s) -o $@" % (ui, ui),
+    )
+
+    hdr = ":%s_uic" % name
+    cc_library(
+        name = name,
+        hdrs = [hdr],
+        deps = deps,
+        copts = QT_INCLUDE_PATHS,
+        linkopts = QT_LINK_PATHS,
+        **kwargs
+    )
+
+def qt_cc_library(name, srcs, hdrs, copts = [], linkopts = [], deps = [], **kwargs):
+    """
+    Creates a cc_library for a Qt component.
+
+    This rule processes Qt header files with the Qt Meta-Object Compiler (moc)
+    and includes them in the library along with the provided sources.
+
+    Args:
+        name (str): The name of the library.
+        srcs (list): A list of source files.
+        hdrs (list): A list of header files to process with moc.
+        copts (list): Additional compiler options.
+        linkopts (list): Additional linker options.
+        deps (list): A list of dependencies for the library.
+        **kwargs: Additional keyword arguments for `cc_library`.
+    """
+    _moc_srcs = []
+    for hdr in hdrs:
+        header_path = "%s/%s" % (native.package_name(), hdr) if len(native.package_name()) > 0 else hdr
+        moc_name = "moc_%s" % hdr.rsplit(".", 1)[0]
+
+        native.genrule(
+            name = moc_name,
+            srcs = [hdr],
+            outs = [moc_name + ".cpp"],
+            cmd = "echo 'Running moc command: /usr/bin/moc $(location %s) -o $@ -f \"%s\"' && /usr/bin/moc $(location %s) -o $@ -f \"%s\"" % (hdr, header_path, hdr, header_path),
+        )
+
+        _moc_srcs.append(":" + moc_name)
+
+    cc_library(
+        name = name,
+        srcs = srcs + _moc_srcs,
+        hdrs = hdrs,
+        deps = deps,
+        copts = copts + QT_INCLUDE_PATHS,
+        linkopts = linkopts + QT_LINK_PATHS,
+        **kwargs
+    )
+
+def qt_cc_binary(name, srcs, deps = None, copts = [], data = [], env = {}, **kwargs):
+    """
+    Creates a cc_binary for a Qt application.
+
+    This rule generates a binary with the necessary environment variables and
+    runtime paths for Qt libraries.
+
+    Args:
+        name (str): The name of the binary.
+        srcs (list): A list of source files for the binary.
+        deps (list): A list of dependencies for the binary.
+        copts (list): Additional compiler options.
+        data (list): Data files to include with the binary.
+        env (dict): Additional environment variables for the binary.
+        **kwargs: Additional keyword arguments for `cc_binary`.
+    """
+    x86_64_env_data = update_dict(x86_64_env, env)
+    aarch64_env_data = update_dict(aarch64_env, env)
+    env_file = []
+    native.genrule(
+        name = name + "_env",
+        outs = ["qt_env.ini"],
+        cmd = select({
+            "@platforms//cpu:x86_64": "echo $$\"LD_LIBRARY_PATH: /usr/lib/x86_64-linux-gnu\" > $@ \
+                    $$\"\r\nQT_QPA_PLATFORM_PLUGIN_PATH: /usr/lib/x86_64-linux-gnu/qt5/plugins/platforms\" > $@ \
+                    $$\"\r\nQML2_IMPORT_PATH: /usr/lib/x86_64-linux-gnu/qt5/qml\" > $@ \
+                    $$\"\r\nQT_PLUGIN_PATH: /usr/lib/x86_64-linux-gnu/qt5/plugins\" > $@",
+            "@platforms//cpu:aarch64": "echo $$\"LD_LIBRARY_PATH: /usr/lib/aarch64-linux-gnu\" > $@ \
+                    $$\"\r\nQT_QPA_PLATFORM_PLUGIN_PATH: /usr/lib/aarch64-linux-gnu/qt5/plugins/platforms\" > $@ \
+                    $$\"\r\nQML2_IMPORT_PATH: /usr/lib/aarch64-linux-gnu/qt5/qml\" > $@ \
+                    $$\"\r\nQT_PLUGIN_PATH: /usr/lib/aarch64-linux-gnu/qt5/plugins\" > $@",
+        }),
+    )
+    env_file.append("qt_env.ini")
+    cc_binary(
+        name = name,
+        srcs = srcs,
+        deps = deps,
+        copts = copts + QT_INCLUDE_PATHS,
+        data = env_file + data,
+        env = select({
+            "@platforms//cpu:x86_64": x86_64_env_data,
+            "@platforms//cpu:aarch64": aarch64_env_data,
+        }),
+        **kwargs
+    )

--- a/examples/qt/BUILD
+++ b/examples/qt/BUILD
@@ -1,15 +1,19 @@
-cc_binary(
+load("//bazel/rules:qt.bzl", "qt_cc_binary", "qt_cc_library", "qt_ui_library")
+
+qt_ui_library(
+    name = "ui",
+    ui = "mainwindow.ui",
+)
+
+qt_cc_library(
+    name = "lib",
+    srcs = ["mainwindow.cpp"],
+    hdrs = ["mainwindow.h"],
+    deps = [":ui"],
+)
+
+qt_cc_binary(
     name = "bin",
     srcs = ["main.cpp"],
-    copts = [
-        "-I/usr/include/x86_64-linux-gnu/qt5",
-        "-I/usr/include/x86_64-linux-gnu/qt5/QtGui",
-        "-I/usr/include/x86_64-linux-gnu/qt5/QtWidgets",
-        "-I/usr/include/x86_64-linux-gnu/qt5/QtCore",
-    ],
-    linkopts = [
-        "-lQt5Widgets",
-        "-lQt5Core",
-        "-lQt5Gui",
-    ],
+    deps = [":lib"],
 )

--- a/examples/qt/README
+++ b/examples/qt/README
@@ -1,5 +1,13 @@
 # How to Run
 
+Run the following command to compile for x86:
+
 ```bash
 bazel run //examples/qt:bin
+```
+
+Run the following command to compile for aarch64:
+
+```bash
+bazel build //examples/qt:bin --platforms=//bazel/platforms:aarch64_linux
 ```

--- a/examples/qt/main.cpp
+++ b/examples/qt/main.cpp
@@ -1,69 +1,12 @@
-#include <QApplication>
-#include <QFont>
-#include <QGridLayout>
-#include <QLCDNumber>
-#include <QPushButton>
-#include <QSlider>
-#include <QVBoxLayout>
-#include <QWidget>
-#include <memory>
+#include <QtWidgets/QApplication>
 
-constexpr int LCD_DIGITS = 2;
-constexpr int SLIDER_MIN = 0;
-constexpr int SLIDER_MAX = 99;
-constexpr int FONT_SIZE = 18;
-
-class LCDRange : public QWidget {
-   public:
-    explicit LCDRange(QWidget *parent = nullptr);
-};
-
-LCDRange::LCDRange(QWidget *parent) : QWidget(parent) {
-    auto lcd = std::make_unique<QLCDNumber>(LCD_DIGITS);
-    lcd->setSegmentStyle(QLCDNumber::Filled);
-
-    auto slider = std::make_unique<QSlider>(Qt::Horizontal);
-    slider->setRange(SLIDER_MIN, SLIDER_MAX);
-    slider->setValue(SLIDER_MIN);
-
-    connect(slider.get(), &QSlider::valueChanged, lcd.get(),
-            static_cast<void (QLCDNumber::*)(int)>(&QLCDNumber::display));
-
-    auto layout = std::make_unique<QVBoxLayout>();
-    layout->addWidget(lcd.release());
-    layout->addWidget(slider.release());
-    setLayout(layout.release());
-}
-
-class MyWidget : public QWidget {
-   public:
-    explicit MyWidget(QWidget *parent = nullptr);
-};
-
-MyWidget::MyWidget(QWidget *parent) : QWidget(parent) {
-    auto quit = std::make_unique<QPushButton>(tr("Quit"));
-    quit->setFont(QFont("Times", FONT_SIZE, QFont::Bold));
-    connect(quit.get(), &QPushButton::clicked, qApp, &QApplication::quit);
-
-    auto grid = std::make_unique<QGridLayout>();
-    for (int row = 0; row < 3; ++row) {
-        for (int column = 0; column < 3; ++column) {
-            auto lcdRange = std::make_unique<LCDRange>();
-            grid->addWidget(lcdRange.release(), row, column);
-        }
-    }
-
-    auto layout = std::make_unique<QVBoxLayout>();
-    layout->addWidget(quit.release());
-    layout->addLayout(grid.release());
-    setLayout(layout.release());
-}
+#include "mainwindow.h"
 
 auto main(int argc, char *argv[]) -> int {
-    const QApplication app(argc, argv);
+    QApplication app(argc, argv);
 
-    MyWidget widget;
-    widget.show();
+    MainWindow window;
+    window.show();
 
-    return QApplication::exec();
+    return app.exec();
 }

--- a/examples/qt/mainwindow.cpp
+++ b/examples/qt/mainwindow.cpp
@@ -1,0 +1,16 @@
+#include "mainwindow.h"
+
+#include <QtWidgets/QMessageBox>
+
+MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
+    ui->setupUi(this);
+
+    connect(ui->pushButton, &QPushButton::clicked, this, &MainWindow::on_pushButton_clicked);
+}
+
+MainWindow::~MainWindow() { delete ui; }
+
+void MainWindow::on_pushButton_clicked() {
+    QString inputText = ui->lineEdit->text();
+    QMessageBox::information(this, "Input", "You entered: " + inputText);
+}

--- a/examples/qt/mainwindow.h
+++ b/examples/qt/mainwindow.h
@@ -1,0 +1,25 @@
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
+
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QLineEdit>
+#include <QtWidgets/QMainWindow>
+#include <QtWidgets/QPushButton>
+
+#include "examples/qt/ui_mainwindow.h"
+
+class MainWindow : public QMainWindow {
+    Q_OBJECT
+
+   public:
+    explicit MainWindow(QWidget *parent = nullptr);
+    ~MainWindow();
+
+   private slots:
+    void on_pushButton_clicked();
+
+   private:
+    Ui::MainWindow *ui;
+};
+
+#endif  // MAINWINDOW_H

--- a/examples/qt/mainwindow.ui
+++ b/examples/qt/mainwindow.ui
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Simple Qt UI</string>
+  </property>
+  <widget class="QWidget" name="centralWidget">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QLabel" name="label">
+      <property name="text">
+       <string>Enter something:</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QLineEdit" name="lineEdit">
+      <property name="placeholderText">
+       <string>Type here...</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="pushButton">
+      <property name="text">
+       <string>Submit</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
## Description

Different files need be generated to enable full Qt functionality.
Custom Bazel rules were added that create `cc_libs` and `cc_bins` and to call genrules for file generation.
The proposed implementation also complies with x86 and aarch64 by allowing linking to different libs.
This is also a required step for upgrading to Qt6.
The custom rules improve the quality of life of the developers and avoid a lot of duplication.

## Checklist

- [x] Code follows project style guidelines.
- [x] Documentation updated (if applicable).
- [x] Tested in simulation/real-world environment (if applicable).

## Testing

Improved example/qt and tested locally.
Tested by building and running on x86 with:

```bash
bazel run //examples/qt:bin
```
and cross-compiled for aarch64:
```bash
bazel build //examples/qt:bin --platforms=//bazel/platforms:aarch64_linux
```

## Related Issue

Issue: https://github.com/SEAME-pt/Team04/issues/99

## Notes

References:
- https://github.com/Vertexwahn/rules_qt6
- https://github.com/bbreslauer/qt-bazel-example/tree/master