### PR TITLE
tooling: update docker image to use gcc-14 and ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive \
+    LLVM_VERSION=18 \
+    GCC_VERSION=14 \
+    QT_VERSION=5.15.5 \
+    QT_RELEASE_URL=https://github.com/parker-int64/qt-aarch64-binary/releases/download/5.15.5 \
+    BAZELISK_URL=https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 \
+    BUILDIFIER_URL=https://github.com/bazelbuild/buildtools/releases/latest/download/buildifier-linux-amd64 \
+    HOME=/root
+
+# Update and install base dependencies
 RUN apt-get update && apt-get install -y \
     build-essential \
     vim \
@@ -31,69 +42,77 @@ RUN apt-get update && apt-get install -y \
     libxcb-xkb1 \
     libxcb-cursor0 \
     locales \
-    qtbase5-dev  \
-    && apt-get clean
-
-RUN wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
-    && echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" | tee -a /etc/apt/sources.list.d/llvm.list
-
-RUN apt-get update && apt-get install -y \
-    llvm-18 \
-    llvm-18-dev \
-    clang-18 \
-    clang-tools-18 \
-    clang-format-18 \
-    clang-tidy-18 \
-    lld-18 \
-    lldb-18
-
-# Cross-compilation
-RUN apt-get install -y \
+    qtbase5-dev \
     gcc-aarch64-linux-gnu \
-    g++-aarch64-linux-gnu
+    g++-aarch64-linux-gnu \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN pip install yamllint
+# Add LLVM repository and install LLVM/Clang tools
+RUN wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
+    echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-${LLVM_VERSION} main" | tee /etc/apt/sources.list.d/llvm.list && \
+    apt-get update && apt-get install -y \
+    llvm-${LLVM_VERSION} \
+    llvm-${LLVM_VERSION}-dev \
+    clang-${LLVM_VERSION} \
+    clangd-${LLVM_VERSION} \
+    clang-tools-${LLVM_VERSION} \
+    clang-format-${LLVM_VERSION} \
+    clang-tidy-${LLVM_VERSION} \
+    lld-${LLVM_VERSION} \
+    lldb-${LLVM_VERSION} \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN pip install gitlint
+# Set up GCC
+RUN apt-get update && apt-get install -y \
+    gcc-${GCC_VERSION} \
+    g++-${GCC_VERSION} \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/install.sh | sh
+# Set up alternatives for LLVM and GCC tools
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VERSION} 100 && \
+    update-alternatives --install /usr/bin/clangd clangd /usr/bin/clangd-${LLVM_VERSION} 100 && \
+    update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-${LLVM_VERSION} 100 && \
+    update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-${LLVM_VERSION} 100 && \
+    update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-${LLVM_VERSION} 100 && \
+    update-alternatives --install /usr/bin/llvm-profdata llvm-profdata /usr/bin/llvm-profdata-${LLVM_VERSION} 100 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 100 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} 100
+
+# Install Arduino lint, yamllint, and gitlint
+RUN curl -fsSL https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/install.sh | sh && \
+    pip install --break-system-packages yamllint gitlint
 
 # Download and extract precompiled Qt aarch64 libs
-ENV RELEASE_URL=https://github.com/parker-int64/qt-aarch64-binary/releases/download/5.15.5
-RUN wget ${RELEASE_URL}/qt-5.15.5-aarch64-cross-compile-gcc-5.tar.gz -O /tmp/qt-aarch64-binary.tar.gz && \
+RUN wget ${QT_RELEASE_URL}/qt-${QT_VERSION}-aarch64-cross-compile-gcc-5.tar.gz -O /tmp/qt-aarch64-binary.tar.gz && \
     mkdir -p /opt/qt && \
-    tar -xzf /tmp/qt-aarch64-binary.tar.gz -C /opt/qt
+    tar -xzf /tmp/qt-aarch64-binary.tar.gz -C /opt/qt && \
+    rm /tmp/qt-aarch64-binary.tar.gz && \
+    mv /opt/qt/qt-${QT_VERSION}-aarch64/lib/* /usr/lib/aarch64-linux-gnu && \
+    cp /usr/aarch64-linux-gnu/lib/* /lib/aarch64-linux-gnu && \
+    cp /usr/aarch64-linux-gnu/lib/ld-linux-aarch64.so.1 /lib
 
-# Download and install libzmq3-dev
+# Install libzmq3-dev
 RUN echo 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_22.04/ /' | \
     tee /etc/apt/sources.list.d/network:messaging:zeromq:release-stable.list && \
     curl -fsSL https://download.opensuse.org/repositories/network:messaging:zeromq:release-stable/xUbuntu_22.04/Release.key | \
     gpg --dearmor | tee /etc/apt/trusted.gpg.d/network_messaging_zeromq_release-stable.gpg > /dev/null && \
-    apt-get update && apt-get install -y libzmq3-dev
+    apt-get update && apt-get install -y libzmq3-dev && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN rm /tmp/qt-aarch64-binary.tar.gz && \
-    mv /opt/qt/qt-5.15.5-aarch64/lib/* /usr/lib/aarch64-linux-gnu
-
-RUN cp /usr/aarch64-linux-gnu/lib/* /lib/aarch64-linux-gnu && \
-    cp /usr/aarch64-linux-gnu/lib/ld-linux-aarch64.so.1 /lib
-
-RUN wget https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 && \
+# Install Bazelisk
+RUN wget ${BAZELISK_URL} && \
     chmod 755 bazelisk-linux-amd64 && \
-    mv bazelisk-linux-amd64 /usr/bin/bazelisk
+    mv bazelisk-linux-amd64 /usr/bin/bazelisk && \
+    ln -s /usr/bin/bazelisk /usr/bin/bazel
 
-ENV HOME=/root
+# Install Buildifier
+RUN wget ${BUILDIFIER_URL} && \
+    chmod 755 buildifier-linux-amd64 && \
+    mv buildifier-linux-amd64 /usr/bin/buildifier
 
-RUN update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-18 100
+# Add bin paths to PATH
+RUN echo 'if [ -d "$HOME/bin" ]; then PATH="$HOME/bin:$PATH"; fi' >> $HOME/.bashrc && \
+    echo 'if [ -d "$HOME/usr/bin" ]; then PATH="$HOME/usr/bin:$PATH"; fi' >> $HOME/.bashrc
 
-RUN update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-18 100
-
-RUN update-alternatives --install /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-18 100
-
-RUN update-alternatives --install /usr/bin/llvm-profdata llvm-profdata /usr/bin/llvm-profdata-18 100
-
-RUN echo "alias bazel='bazelisk'" >> $HOME/.bashrc
-
-RUN echo 'if [ -d "$HOME/bin" ] ; then\n    PATH="$HOME/bin:$PATH"\nfi' >> $HOME/.bashrc && \
-    echo 'if [ -d "$HOME/usr/bin" ] ; then\n    PATH="$HOME/usr/bin:$PATH"\nfi' >> $HOME/.bashrc
-
+# Configure Git
 RUN git config --global --add safe.directory /Team04


### PR DESCRIPTION
## Description

Updated docker image configuration with:

- Base image Ubuntu 24.04
- `gcc-14`

Also reorganized the Dockerfile for better structure.

## Checklist

- [x] Code follows project style guidelines.
- [x] Tested in simulation/real-world environment (if applicable).

## Testing

Tested locally and on the CI running github actions.

## Related Issue

Issue: https://github.com/SEAME-pt/Team04/issues/104

## Notes

`gcc-14` package is [not available for Ubuntu 22.04](https://askubuntu.com/a/1513162).