### PR TITLE
ci: automate docker build and push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,40 @@
+---
+name: Docker
+
+on:  # yamllint disable-line rule:truthy
+  # Schedule: Run at 00:00 AM UTC
+  schedule:
+    - cron: '00 00 * * *'
+
+  # Trigger on push to the main branch when the Dockerfile changes
+  push:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile'
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: t4seame/app:latest
+
+      - name: Logout from Docker Hub
+        run: docker logout


### PR DESCRIPTION
## Description

Add action to build and push DOCKERFILE, that triggers if changes in DOCKERFILE are merged and everyday at midnight. 

## Checklist

- [x] Code follows project style guidelines.

## Testing

Tested on the CI changing action to trigger on branch push.

## Related Issue

Issue: https://github.com/SEAME-pt/Team04/issues/113

## Notes:

After merge, image used by other github actions is going to be changed on follow-up PR.
Docker hub: https://hub.docker.com/r/t4seame/app
