### PR TITLE
toolchain: update to qt6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,12 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive \
     LLVM_VERSION=18 \
     GCC_VERSION=12 \
-    QT_VERSION=5.15.5 \
-    QT_RELEASE_URL=https://github.com/parker-int64/qt-aarch64-binary/releases/download/5.15.5 \
     BAZELISK_URL=https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64 \
     BUILDIFIER_URL=https://github.com/bazelbuild/buildtools/releases/latest/download/buildifier-linux-amd64 \
     PIGPIO_URL=https://github.com/joan2937/pigpio \
     HOME=/root
 
-# Update and install base dependencies
+# Install base dependencies
 RUN apt-get update && apt-get install -y \
     build-essential \
     vim \
@@ -22,30 +20,41 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     cmake \
     lcov \
-    file \
-    mesa-common-dev \
-    mesa-utils \
-    libvulkan-dev \
-    libxkbcommon-x11-0 \
-    libxkbcommon-dev \
-    software-properties-common \
-    libgl1-mesa-dev \
-    libxcb-xinerama0 \
-    libxcb-xinput0 \
-    libxcb-icccm4 \
-    libxcb-image0 \
-    libxcb-keysyms1 \
-    libxcb-randr0 \
-    libxcb-render-util0 \
-    libxcb-shape0 \
-    libxcb-sync1 \
-    libxcb-xfixes0 \
-    libxcb-xkb1 \
-    libxcb-cursor0 \
     locales \
-    qtbase5-dev \
-    gcc-${GCC_VERSION}-aarch64-linux-gnu \
-    g++-${GCC_VERSION}-aarch64-linux-gnu \
+    file \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install recommended Qt6 dependencies
+RUN apt-get update && apt-get install -y \
+    libfontconfig1-dev \
+    libfreetype-dev \
+    libx11-dev \
+    libx11-xcb-dev \
+    libxcb-cursor-dev \
+    libxcb-glx0-dev \
+    libxcb-icccm4-dev \
+    libxcb-image0-dev \
+    libxcb-keysyms1-dev \
+    libxcb-randr0-dev \
+    libxcb-render-util0-dev \
+    libxcb-shape0-dev \
+    libxcb-shm0-dev \
+    libxcb-sync-dev \
+    libxcb-util-dev \
+    libxcb-xfixes0-dev \
+    libxcb-xinerama0-dev \
+    libxcb-xkb-dev \
+    libxcb1-dev \
+    libxext-dev \
+    libxfixes-dev \
+    libxi-dev \
+    libxkbcommon-dev \
+    libxkbcommon-x11-dev \
+    libxrender-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install other dependencies
+RUN apt-get update && apt-get install -y \
     libsdl2-dev \
     && rm -rf /var/lib/apt/lists/*
 
@@ -68,6 +77,8 @@ RUN wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted
 RUN apt-get update && apt-get install -y \
     gcc-${GCC_VERSION} \
     g++-${GCC_VERSION} \
+    gcc-${GCC_VERSION}-aarch64-linux-gnu \
+    g++-${GCC_VERSION}-aarch64-linux-gnu \
     && rm -rf /var/lib/apt/lists/*
 
 # Set up alternatives for LLVM and GCC tools
@@ -86,38 +97,37 @@ RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VER
 RUN curl -fsSL https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/install.sh | sh && \
     pip install --break-system-packages yamllint gitlint
 
-# Download and extract precompiled Qt aarch64 libs
-RUN wget ${QT_RELEASE_URL}/qt-${QT_VERSION}-aarch64-cross-compile-gcc-5.tar.gz -O /tmp/qt-aarch64-binary.tar.gz && \
-    mkdir -p /opt/qt && \
-    tar -xzf /tmp/qt-aarch64-binary.tar.gz -C /opt/qt && \
-    rm /tmp/qt-aarch64-binary.tar.gz && \
-    mv /opt/qt/qt-${QT_VERSION}-aarch64/lib/* /usr/lib/aarch64-linux-gnu && \
-    cp /usr/aarch64-linux-gnu/lib/* /lib/aarch64-linux-gnu && \
-    cp /usr/aarch64-linux-gnu/lib/ld-linux-aarch64.so.1 /lib
-
 # Replace ubuntu.sources config file
 COPY config/ubuntu.sources /tmp/ubuntu.sources
-RUN cp /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.bak && \ 
+RUN cp /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources.bak && \
     mv /tmp/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources
 
-# Adding foreign architecture to 
+# Add arm64 architecture
 RUN dpkg --add-architecture arm64
 
-# Install libzmq3-dev
+# Install libzmq3-dev for x86 and arm64
 RUN echo 'deb http://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/xUbuntu_22.04/ /' | \
     tee /etc/apt/sources.list.d/network:messaging:zeromq:release-stable.list && \
     curl -fsSL https://download.opensuse.org/repositories/network:messaging:zeromq:release-stable/xUbuntu_22.04/Release.key | \
     gpg --dearmor | tee /etc/apt/trusted.gpg.d/network_messaging_zeromq_release-stable.gpg > /dev/null && \
-    apt-get update && apt-get install -y libzmq3-dev && apt-get install -y libzmq3-dev:arm64 && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get update && apt-get install -y \
+    libzmq3-dev \
+    libzmq3-dev:arm64 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Qt6 for x86 and arm64
+RUN apt-get update && apt-get install -y \
+    qt6-base-dev \
+    qt6-base-dev:arm64 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install pigpio for x86
 RUN git clone ${PIGPIO_URL}.git && \
     cd pigpio && \
     git checkout v79 && \
     make && \
-    make install && \
-    rm -rf pigpio
+    make install \
+    && rm -rf pigpio
 
 # Install Bazelisk
 RUN wget ${BAZELISK_URL} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,8 +90,8 @@ RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${LLVM_VER
     update-alternatives --install /usr/bin/llvm-profdata llvm-profdata /usr/bin/llvm-profdata-${LLVM_VERSION} 100 && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 100 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} 100 && \
-    update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-{GCC_VERSION} 100 && \
-    update-alternatives --install /usr/bin/x86_64-linux-gnu-gcc x86_64-linux-gnu-gcc /usr/bin/x86_64-linux-gnu-gcc-{GCC_VERSION} 100
+    update-alternatives --install /usr/bin/aarch64-linux-gnu-gcc aarch64-linux-gnu-gcc /usr/bin/aarch64-linux-gnu-gcc-${GCC_VERSION} 100 && \
+    update-alternatives --install /usr/bin/x86_64-linux-gnu-gcc x86_64-linux-gnu-gcc /usr/bin/x86_64-linux-gnu-gcc-${GCC_VERSION} 100
 
 # Install Arduino lint, yamllint, and gitlint
 RUN curl -fsSL https://raw.githubusercontent.com/arduino/arduino-lint/main/etc/install.sh | sh && \

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ A baseline mechanism for coverage is not yet implemented but will be added in th
 
 ## 3. Releases
 
-A new release is automatically created for every push to a tag that matches the pattern `v*`."
+A new release is automatically created for every push to a tag that matches the pattern `v*`.
 
 To create a tag use the command:
 

--- a/bazel/rules/qt.bzl
+++ b/bazel/rules/qt.bzl
@@ -8,40 +8,47 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
 QT_INCLUDE_PATHS = select({
     "@platforms//cpu:x86_64": [
-        "-I/usr/include/x86_64-linux-gnu/qt5",
-        "-I/usr/include/x86_64-linux-gnu/qt5/QtGui",
-        "-I/usr/include/x86_64-linux-gnu/qt5/QtWidgets",
-        "-I/usr/include/x86_64-linux-gnu/qt5/QtCore",
+        "-I/usr/include/x86_64-linux-gnu/qt6",
+        "-I/usr/include/x86_64-linux-gnu/qt6/QtGui",
+        "-I/usr/include/x86_64-linux-gnu/qt6/QtWidgets",
+        "-I/usr/include/x86_64-linux-gnu/qt6/QtCore",
     ],
     "@platforms//cpu:aarch64": [
-        "-I/usr/include/x86_64-linux-gnu/qt5",
-        "-I/usr/include/x86_64-linux-gnu/qt5/QtGui",
-        "-I/usr/include/x86_64-linux-gnu/qt5/QtWidgets",
-        "-I/usr/include/x86_64-linux-gnu/qt5/QtCore",
+        "-I/usr/include/aarch64-linux-gnu/qt6",
+        "-I/usr/include/aarch64-linux-gnu/qt6/QtGui",
+        "-I/usr/include/aarch64-linux-gnu/qt6/QtWidgets",
+        "-I/usr/include/aarch64-linux-gnu/qt6/QtCore",
     ],
 })
 
-QT_LINK_PATHS = [
-    "-lQt5Widgets",
-    "-lQt5Core",
-    "-lQt5Gui",
-]
+QT_LINK_PATHS = select({
+    "@platforms//cpu:x86_64": [
+        "-lQt6Widgets",
+        "-lQt6Core",
+        "-lQt6Gui",
+    ],
+    "@platforms//cpu:aarch64": [
+        "-lQt6Widgets",
+        "-lQt6Core",
+        "-lQt6Gui",
+    ],
+})
 
 qt_plugin_data = select({
-    "@platforms//cpu:x86_64": ["/usr/lib/x86_64-linux-gnu", "/usr/lib/x86_64-linux-gnu/plugins", "/usr/lib/x86_64-linux-gnu/qml"],
-    "@platforms//cpu:aarch64": ["/usr/lib/aarch64-linux-gnu", "/usr/lib/aarch64-linux-gnu/plugins", "/usr/lib/aarch64-linux-gnu/qml"],
+    "@platforms//cpu:x86_64": ["/usr/lib/x86_64-linux-gnu", "/usr/lib/x86_64-linux-gnu/qt6/plugins", "/usr/lib/x86_64-linux-gnu/qt6/qml"],
+    "@platforms//cpu:aarch64": ["/usr/lib/aarch64-linux-gnu", "/usr/lib/x86_64-linux-gnu/qt6/plugins", "/usr/lib/aarch64-linux-gnu/qt6/qml"],
 })
 
 x86_64_env = {
-    "QT_PLUGIN_PATH": "/usr/lib/x86_64-linux-gnu/plugins",
-    "QT_QPA_PLATFORM_PLUGIN_PATH": "/usr/lib/x86_64-linux-gnu/plugins/platforms",
-    "QML2_IMPORT_PATH": "/usr/lib/x86_64-linux-gnu/qml",
+    "QT_PLUGIN_PATH": "/usr/lib/x86_64-linux-gnu/qt6/plugins",
+    "QT_QPA_PLATFORM_PLUGIN_PATH": "/usr/lib/x86_64-linux-gnu/qt6/plugins/platforms",
+    "QML2_IMPORT_PATH": "/usr/lib/x86_64-linux-gnu/qt6/qml",
 }
 
 aarch64_env = {
-    "QT_PLUGIN_PATH": "/usr/lib/aarch64-linux-gnu/plugins",
-    "QT_QPA_PLATFORM_PLUGIN_PATH": "/usr/lib/aarch64-linux-gnu/plugins/platforms",
-    "QML2_IMPORT_PATH": "/usr/lib/aarch64-linux-gnu/qml",
+    "QT_PLUGIN_PATH": "/usr/lib/aarch64-linux-gnu/qt6/plugins",
+    "QT_QPA_PLATFORM_PLUGIN_PATH": "/usr/lib/aarch64-linux-gnu/qt6/plugins/platforms",
+    "QML2_IMPORT_PATH": "/usr/lib/aarch64-linux-gnu/qt6/qml",
 }
 
 def update_dict(source, env):
@@ -67,7 +74,7 @@ def qt_ui_library(name, ui, deps = None, **kwargs):
         name = "%s_uic" % name,
         srcs = [ui],
         outs = ["ui_%s.h" % ui.split(".")[0]],
-        cmd = "echo 'Running uic command: uic $(location %s) -o $@' && uic $(location %s) -o $@" % (ui, ui),
+        cmd = "echo 'Running uic command: /usr/lib/qt6/libexec/uic $(location %s) -o $@' && /usr/lib/qt6/libexec/uic $(location %s) -o $@" % (ui, ui),
     )
 
     hdr = ":%s_uic" % name
@@ -105,7 +112,7 @@ def qt_cc_library(name, srcs, hdrs, copts = [], linkopts = [], deps = [], **kwar
             name = moc_name,
             srcs = [hdr],
             outs = [moc_name + ".cpp"],
-            cmd = "echo 'Running moc command: /usr/bin/moc $(location %s) -o $@ -f \"%s\"' && /usr/bin/moc $(location %s) -o $@ -f \"%s\"" % (hdr, header_path, hdr, header_path),
+            cmd = "echo 'Running moc command: /usr/lib/qt6/libexec/moc $(location %s) -o $@ -f \"%s\"' && /usr/lib/qt6/libexec/moc $(location %s) -o $@ -f \"%s\"" % (hdr, header_path, hdr, header_path),
         )
 
         _moc_srcs.append(":" + moc_name)
@@ -144,13 +151,13 @@ def qt_cc_binary(name, srcs, deps = None, copts = [], data = [], env = {}, **kwa
         outs = ["qt_env.ini"],
         cmd = select({
             "@platforms//cpu:x86_64": "echo $$\"LD_LIBRARY_PATH: /usr/lib/x86_64-linux-gnu\" > $@ \
-                    $$\"\r\nQT_QPA_PLATFORM_PLUGIN_PATH: /usr/lib/x86_64-linux-gnu/qt5/plugins/platforms\" > $@ \
-                    $$\"\r\nQML2_IMPORT_PATH: /usr/lib/x86_64-linux-gnu/qt5/qml\" > $@ \
-                    $$\"\r\nQT_PLUGIN_PATH: /usr/lib/x86_64-linux-gnu/qt5/plugins\" > $@",
+                    $$\"\r\nQT_QPA_PLATFORM_PLUGIN_PATH: /usr/lib/x86_64-linux-gnu/qt6/plugins/platforms\" > $@ \
+                    $$\"\r\nQML2_IMPORT_PATH: /usr/lib/x86_64-linux-gnu/qt6/qml\" > $@ \
+                    $$\"\r\nQT_PLUGIN_PATH: /usr/lib/x86_64-linux-gnu/qt6/plugins\" > $@",
             "@platforms//cpu:aarch64": "echo $$\"LD_LIBRARY_PATH: /usr/lib/aarch64-linux-gnu\" > $@ \
-                    $$\"\r\nQT_QPA_PLATFORM_PLUGIN_PATH: /usr/lib/aarch64-linux-gnu/qt5/plugins/platforms\" > $@ \
-                    $$\"\r\nQML2_IMPORT_PATH: /usr/lib/aarch64-linux-gnu/qt5/qml\" > $@ \
-                    $$\"\r\nQT_PLUGIN_PATH: /usr/lib/aarch64-linux-gnu/qt5/plugins\" > $@",
+                    $$\"\r\nQT_QPA_PLATFORM_PLUGIN_PATH: /usr/lib/aarch64-linux-gnu/qt6/plugins/platforms\" > $@ \
+                    $$\"\r\nQML2_IMPORT_PATH: /usr/lib/aarch64-linux-gnu/qt6/qml\" > $@ \
+                    $$\"\r\nQT_PLUGIN_PATH: /usr/lib/aarch64-linux-gnu/qt6/plugins\" > $@",
         }),
     )
     env_file.append("qt_env.ini")


### PR DESCRIPTION
## Description

Update toolchain to use qt6.

## Checklist

- [x] Code follows project style guidelines.
- [ ] Tests added or updated.
- [ ] Documentation updated (if applicable).
- [x] Tested in simulation/real-world environment (if applicable).

## Testing

Tested locally.

## Related Issue

Issue: https://github.com/SEAME-pt/Team04/issues/96

## Notes

This also fixes failure caused by missing `libxcb.so` when trying to run aarch64 binaries on x86.
So now its possible to run and display arm64 bin s locally on x86, with the following command:

```bash
bazel run //examples/qt:bin --platforms=//bazel/platforms:aarch64_linux
```