### PR TITLE
toolchain: add SDL2 and pigpio

### DIFF
--- a/examples/gpio_sdl/BUILD
+++ b/examples/gpio_sdl/BUILD
@@ -1,0 +1,33 @@
+cc_library(
+    name = "lib",
+    srcs = [
+        "gpio_sdl.cpp",
+    ],
+    hdrs = [
+        "gpio_sdl.h",
+    ],
+    features = ["warnings_critical_code_gcc"],
+    linkopts = select({
+        "@platforms//cpu:x86_64": [
+            "-L/usr/lib/x86_64-linux-gnu",
+            "-lpigpio",
+            "-lrt",
+            "-lSDL2",
+        ],
+        "@platforms//cpu:aarch64": [
+            "-L/usr/lib/aarch64-linux-gnu",
+            "-lpigpio",
+            "-lrt",
+            "-lSDL2",
+        ],
+    }),
+)
+
+cc_binary(
+    name = "bin",
+    srcs = ["main.cpp"],
+    features = ["warnings_critical_code_gcc"],
+    deps = [
+        ":lib",
+    ],
+)

--- a/examples/gpio_sdl/README
+++ b/examples/gpio_sdl/README
@@ -1,0 +1,13 @@
+# How to Run
+
+Run the following command to compile for x86:
+
+```bash
+bazel build //examples/gpio_sdl:bin
+```
+
+Run the following command to compile for aarch64:
+
+```bash
+bazel build //examples/gpio_sdl:bin --platforms=//bazel/platforms:aarch64_linux
+```

--- a/examples/gpio_sdl/gpio_sdl.cpp
+++ b/examples/gpio_sdl/gpio_sdl.cpp
@@ -1,0 +1,43 @@
+#include "gpio_sdl.h"
+
+#include <pigpio.h>
+
+#include <iostream>
+
+bool initGPIO() {
+    if (gpioInitialise() < 0) {
+        std::cerr << "Failed to initialize pigpio." << std::endl;
+        return false;
+    }
+    return true;
+}
+
+int readButtonState(int gpioPin) { return gpioRead(static_cast<unsigned int>(gpioPin)); }
+
+bool initSDL(SDL_Window*& window, SDL_Renderer*& renderer) {
+    if (SDL_Init(SDL_INIT_VIDEO) < 0) {
+        std::cerr << "Failed to initialize SDL: " << SDL_GetError() << std::endl;
+        return false;
+    }
+    window = SDL_CreateWindow("GPIO + SDL2 Example", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+                              640, 480, SDL_WINDOW_SHOWN);
+    if (!window) {
+        std::cerr << "Failed to create SDL window: " << SDL_GetError() << std::endl;
+        return false;
+    }
+    renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
+    if (!renderer) {
+        std::cerr << "Failed to create SDL renderer: " << SDL_GetError() << std::endl;
+        SDL_DestroyWindow(window);
+        return false;
+    }
+    return true;
+}
+
+void cleanupSDL(SDL_Window* window, SDL_Renderer* renderer) {
+    SDL_DestroyRenderer(renderer);
+    SDL_DestroyWindow(window);
+    SDL_Quit();
+}
+
+void cleanupGPIO() { gpioTerminate(); }

--- a/examples/gpio_sdl/gpio_sdl.h
+++ b/examples/gpio_sdl/gpio_sdl.h
@@ -1,0 +1,12 @@
+#ifndef GPIO_SDL_H
+#define GPIO_SDL_H
+
+#include <SDL2/SDL.h>
+
+bool initGPIO();
+int readButtonState(int gpioPin);
+bool initSDL(SDL_Window*& window, SDL_Renderer*& renderer);
+void cleanupSDL(SDL_Window* window, SDL_Renderer* renderer);
+void cleanupGPIO();
+
+#endif  // GPIO_SDL_H

--- a/examples/gpio_sdl/main.cpp
+++ b/examples/gpio_sdl/main.cpp
@@ -1,0 +1,53 @@
+#include <pigpio.h>
+
+#include <iostream>
+
+#include "gpio_sdl.h"
+
+#define GPIO_BUTTON 17
+
+int main() {
+    if (!initGPIO()) {
+        return -1;
+    }
+    gpioSetMode(GPIO_BUTTON, PI_INPUT);
+    gpioSetPullUpDown(GPIO_BUTTON, PI_PUD_UP);
+
+    SDL_Window* window = nullptr;
+    SDL_Renderer* renderer = nullptr;
+    if (!initSDL(window, renderer)) {
+        cleanupGPIO();
+        return -1;
+    }
+
+    bool running = true;
+    while (running) {
+        SDL_Event event;
+        while (SDL_PollEvent(&event)) {
+            if (event.type == SDL_QUIT) {
+                running = false;
+            }
+        }
+
+        int buttonState = readButtonState(GPIO_BUTTON);
+
+        SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+        SDL_RenderClear(renderer);
+
+        if (buttonState == 0) {
+            SDL_SetRenderDrawColor(renderer, 0, 255, 0, 255);
+        } else {
+            SDL_SetRenderDrawColor(renderer, 255, 0, 0, 255);
+        }
+        SDL_Rect rect = {220, 140, 200, 200};
+        SDL_RenderFillRect(renderer, &rect);
+
+        SDL_RenderPresent(renderer);
+
+        SDL_Delay(16);
+    }
+
+    cleanupSDL(window, renderer);
+    cleanupGPIO();
+    return 0;
+}

--- a/toolchain/aarch64_linux/cc_toolchain_config.bzl
+++ b/toolchain/aarch64_linux/cc_toolchain_config.bzl
@@ -245,6 +245,7 @@ def _impl(ctx):
         features = features,
         cxx_builtin_include_directories = [
             "/usr/include",
+            "/usr/local/include",
             "/usr/aarch64-linux-gnu",
             "/usr/lib/aarch64-linux-gnu",
             "/usr/lib/gcc-cross/aarch64-linux-gnu",

--- a/toolchain/x86_64_linux/cc_toolchain_config.bzl
+++ b/toolchain/x86_64_linux/cc_toolchain_config.bzl
@@ -243,6 +243,7 @@ def _impl(ctx):
         features = features,
         cxx_builtin_include_directories = [
             "/usr/include",
+            "/usr/local/include",
             "/usr/lib/x86_64-linux-gnu",
             "/usr/lib/gcc/x86_64-linux-gnu",
         ],

--- a/tools/cross_compilation/pigpio/makefile
+++ b/tools/cross_compilation/pigpio/makefile
@@ -1,0 +1,162 @@
+#
+# Set CROSS_PREFIX to prepend to all compiler tools at once for easier
+# cross-compilation.
+CC           = $(CROSS_PREFIX)-gcc
+AR           = $(CROSS_PREFIX)-ar
+RANLIB       = $(CROSS_PREFIX)-ranlib
+SIZE         = $(CROSS_PREFIX)-size
+STRIP        = $(CROSS_PREFIX)-strip
+SHLIB        = $(CC) -shared
+STRIPLIB     = $(STRIP) --strip-unneeded
+
+SOVERSION    = 1
+
+CFLAGS	+= -O3 -Wall -pthread
+
+LIB1     = libpigpio.so
+OBJ1     = pigpio.o command.o
+
+LIB2     = libpigpiod_if.so
+OBJ2     = pigpiod_if.o command.o
+
+LIB3     = libpigpiod_if2.so
+OBJ3     = pigpiod_if2.o command.o
+
+LIB      = $(LIB1) $(LIB2) $(LIB3)
+
+ALL     = $(LIB) x_pigpio x_pigpiod_if x_pigpiod_if2 pig2vcd pigpiod pigs
+
+LL1      = -L. -lpigpio -pthread -lrt
+
+LL2      = -L. -lpigpiod_if -pthread -lrt
+
+LL3      = -L. -lpigpiod_if2 -pthread -lrt
+
+prefix=/usr/opt
+exec_prefix = $(prefix)
+bindir = $(prefix)/bin
+includedir = $(prefix)/include
+libdir = $(prefix)/lib
+mandir = $(prefix)/man
+
+all:	$(ALL)
+
+lib:	$(LIB)
+
+pigpio.o: pigpio.c pigpio.h command.h custom.cext
+	$(CC) $(CFLAGS) -fpic -c -o pigpio.o pigpio.c
+
+pigpiod_if.o: pigpiod_if.c pigpio.h command.h pigpiod_if.h
+	$(CC) $(CFLAGS) -fpic -c -o pigpiod_if.o pigpiod_if.c
+
+pigpiod_if2.o: pigpiod_if2.c pigpio.h command.h pigpiod_if2.h
+	$(CC) $(CFLAGS) -fpic -c -o pigpiod_if2.o pigpiod_if2.c
+
+command.o: command.c pigpio.h command.h
+	$(CC) $(CFLAGS) -fpic -c -o command.o command.c
+
+x_pigpio:	x_pigpio.o $(LIB1)
+	$(CC) -o x_pigpio x_pigpio.o $(LL1)
+
+x_pigpiod_if:	x_pigpiod_if.o $(LIB2)
+	$(CC) -o x_pigpiod_if x_pigpiod_if.o $(LL2)
+
+x_pigpiod_if2:	x_pigpiod_if2.o $(LIB3)
+	$(CC) -o x_pigpiod_if2 x_pigpiod_if2.o $(LL3)
+
+pigpiod:	pigpiod.o $(LIB1)
+	$(CC) -o pigpiod pigpiod.o $(LL1)
+	$(STRIP) pigpiod
+
+pigs:		pigs.o command.o
+	$(CC) -o pigs pigs.o command.o
+	$(STRIP) pigs
+
+pig2vcd:	pig2vcd.o
+	$(CC) -o pig2vcd pig2vcd.o
+	$(STRIP) pig2vcd
+
+clean:
+	rm -f *.o *.i *.s *~ $(ALL) *.so.$(SOVERSION)
+
+ifeq ($(DESTDIR),)
+  PYINSTALLARGS =
+else
+  PYINSTALLARGS = --root=$(DESTDIR)
+endif
+
+install:	$(ALL)
+	install -m 0755 -d                             $(DESTDIR)/opt/pigpio/cgi
+	install -m 0755 -d                             $(DESTDIR)$(includedir)
+	install -m 0644 pigpio.h                       $(DESTDIR)$(includedir)
+	install -m 0644 pigpiod_if.h                   $(DESTDIR)$(includedir)
+	install -m 0644 pigpiod_if2.h                  $(DESTDIR)$(includedir)
+	install -m 0755 -d                             $(DESTDIR)$(libdir)
+	install -m 0755 libpigpio.so.$(SOVERSION)      $(DESTDIR)$(libdir)
+	install -m 0755 libpigpiod_if.so.$(SOVERSION)  $(DESTDIR)$(libdir)
+	install -m 0755 libpigpiod_if2.so.$(SOVERSION) $(DESTDIR)$(libdir)
+	cd $(DESTDIR)$(libdir) && ln -fs libpigpio.so.$(SOVERSION)      libpigpio.so
+	cd $(DESTDIR)$(libdir) && ln -fs libpigpiod_if.so.$(SOVERSION)  libpigpiod_if.so
+	cd $(DESTDIR)$(libdir) && ln -fs libpigpiod_if2.so.$(SOVERSION) libpigpiod_if2.so
+	install -m 0755 -d                             $(DESTDIR)$(bindir)
+	install -m 0755 pig2vcd                        $(DESTDIR)$(bindir)
+	install -m 0755 pigpiod                        $(DESTDIR)$(bindir)
+	install -m 0755 pigs                           $(DESTDIR)$(bindir)
+	if which python2; then python2 setup.py install $(PYINSTALLARGS); fi
+	if which python3; then python3 setup.py install $(PYINSTALLARGS); fi
+	install -m 0755 -d                             $(DESTDIR)$(mandir)/man1
+	install -m 0644 p*.1                           $(DESTDIR)$(mandir)/man1
+	install -m 0755 -d                             $(DESTDIR)$(mandir)/man3
+	install -m 0644 p*.3                           $(DESTDIR)$(mandir)/man3
+ifeq ($(DESTDIR),)
+	ldconfig
+endif
+
+uninstall:
+	rm -f $(DESTDIR)$(includedir)/pigpio.h
+	rm -f $(DESTDIR)$(includedir)/pigpiod_if.h
+	rm -f $(DESTDIR)$(includedir)/pigpiod_if2.h
+	rm -f $(DESTDIR)$(libdir)/libpigpio.so
+	rm -f $(DESTDIR)$(libdir)/libpigpiod_if.so
+	rm -f $(DESTDIR)$(libdir)/libpigpiod_if2.so
+	rm -f $(DESTDIR)$(libdir)/libpigpio.so.$(SOVERSION)
+	rm -f $(DESTDIR)$(libdir)/libpigpiod_if.so.$(SOVERSION)
+	rm -f $(DESTDIR)$(libdir)/libpigpiod_if2.so.$(SOVERSION)
+	rm -f $(DESTDIR)$(bindir)/pig2vcd
+	rm -f $(DESTDIR)$(bindir)/pigpiod
+	rm -f $(DESTDIR)$(bindir)/pigs
+	if which python2; then python2 setup.py install $(PYINSTALLARGS) --record /tmp/pigpio >/dev/null; sed 's!^!$(DESTDIR)!' < /tmp/pigpio | xargs rm -f >/dev/null; fi
+	if which python3; then python3 setup.py install $(PYINSTALLARGS) --record /tmp/pigpio >/dev/null; sed 's!^!$(DESTDIR)!' < /tmp/pigpio | xargs rm -f >/dev/null; fi
+	rm -f $(DESTDIR)$(mandir)/man1/pig*.1
+	rm -f $(DESTDIR)$(mandir)/man1/libpigpio*.1
+	rm -f $(DESTDIR)$(mandir)/man3/pig*.3
+ifeq ($(DESTDIR),)
+	ldconfig
+endif
+
+$(LIB1):	$(OBJ1)
+	$(SHLIB) -pthread -Wl,-soname,$(LIB1).$(SOVERSION) -o $(LIB1).$(SOVERSION) $(OBJ1)
+	ln -fs $(LIB1).$(SOVERSION) $(LIB1)
+	$(STRIPLIB) $(LIB1)
+	$(SIZE)     $(LIB1)
+
+$(LIB2):	$(OBJ2)
+	$(SHLIB) -pthread -Wl,-soname,$(LIB2).$(SOVERSION) -o $(LIB2).$(SOVERSION) $(OBJ2)
+	ln -fs $(LIB2).$(SOVERSION) $(LIB2)
+	$(STRIPLIB) $(LIB2)
+	$(SIZE)     $(LIB2)
+
+$(LIB3):	$(OBJ3)
+	$(SHLIB) -pthread -Wl,-soname,$(LIB3).$(SOVERSION) -o $(LIB3).$(SOVERSION) $(OBJ3)
+	ln -fs $(LIB3).$(SOVERSION) $(LIB3)
+	$(STRIPLIB) $(LIB3)
+	$(SIZE)     $(LIB3)
+
+# generated using gcc -MM *.c
+
+pig2vcd.o: pig2vcd.c pigpio.h
+pigpiod.o: pigpiod.c pigpio.h
+pigs.o: pigs.c pigpio.h command.h pigs.h
+x_pigpio.o: x_pigpio.c pigpio.h
+x_pigpiod_if.o: x_pigpiod_if.c pigpiod_if.h pigpio.h
+x_pigpiod_if2.o: x_pigpiod_if2.c pigpiod_if2.h pigpio.h


### PR DESCRIPTION
## Description

Add [SDL2](https://wiki.libsdl.org/SDL2/Installation) and [pigpio](https://abyz.me.uk/rpi/pigpio/download.html) to toolchain.
Adding `SDL2` is straightforward however `pigpio` required compiling from source for both `x86` and `arm64`.

## Checklist

- [x] Code follows project style guidelines.
- [ ] Tests added or updated.
- [ ] Documentation updated (if applicable).
- [x] Tested in simulation/real-world environment (if applicable).

## Testing

Able to cross-compile and bins run on target.

## Related Issue

Issue: https://github.com/SEAME-pt/Team04/issues/125

## Notes

The makefile is mainly identical to the one from [pigpio repo](https://github.com/joan2937/pigpio/blob/master/Makefile).
This PR uses temporary solution to get cross-compilation working, that is finding and copying pigpio files.
There is a problem setting the [destination path](https://github.com/joan2937/pigpio/issues/36) on the official makefile. A follow-up will improve this implementation.