### PR TITLE
ci: add cache to docker build github action

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -30,6 +30,18 @@ jobs:
             fi
           done < affected_files.txt
 
+      - name: Setup docker cache
+        if: env.dockerfile_changed == 'true'
+        uses: actions/cache@v4
+        env:
+          cache-name: docker-cache
+        with:
+          path: |
+            ~/.cache/docker
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-developmen
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         if: env.dockerfile_changed == 'true'

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,8 @@ RUN apt-get update && apt-get install -y \
 
 # Install other dependencies
 RUN apt-get update && apt-get install -y \
-    libsdl2-dev \
-    && rm -rf /var/lib/apt/lists/*
+    libsdl2-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 # Add LLVM repository and install LLVM/Clang tools
 RUN wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \


### PR DESCRIPTION
## Description

Add caching to the Docker build GitHub Actions to speed up subsequent builds.

## Checklist

- [x] Code follows project style guidelines.
- [ ] Tests added or updated.
- [ ] Documentation updated (if applicable).
- [x] Tested in simulation/real-world environment (if applicable).

## Testing

CI

## Related Issue

Issue: https://github.com/SEAME-pt/jet_racers/issues/38

