### PR TITLE
ci: deploy github pages with coverage report

### DIFF
--- a/.github/workflows/coverage_deploy.yml
+++ b/.github/workflows/coverage_deploy.yml
@@ -1,0 +1,68 @@
+# yamllint disable rule:line-length
+---
+name: Coverage
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    container:
+      image: t4seame/app:latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create coverage directory
+        run: |
+          mkdir -p "./lcov_report/gcno_gcda"
+
+      - name: Generate coverage report
+        run: |
+          PLATFORM_TARGETS=$(bazel query 'kind("cc_binary|cc_library", //platform/...) except kind(.*test, //...)')
+          MIDDLEWARE_TARGETS=$(bazel query 'kind("cc_binary|cc_library", //com-middleware/...) except kind(.*test, //...)')
+          ALL_TARGETS=$(echo "$PLATFORM_TARGETS $MIDDLEWARE_TARGETS" | tr '\n' ' ')
+
+          echo "All Targets: $ALL_TARGETS"
+
+          BAZEL_BIN=$(bazel info bazel-bin)
+          TEST_LOGS=$(bazel info bazel-testlogs)
+
+          echo "Bazel bin directory: $BAZEL_BIN"
+          echo "Test logs directory: $TEST_LOGS"
+
+          bazelisk run //tools/coverage:lcov \
+            --platforms=//bazel/platforms:x86_64_linux -- \
+            -b "$ALL_TARGETS" \
+            -t //:unit_tests \
+            -c "$BAZEL_BIN" \
+            -d "$TEST_LOGS" \
+            -o "./lcov_report"
+        shell: bash
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './lcov_report'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/coverage_summary.yml
+++ b/.github/workflows/coverage_summary.yml
@@ -6,7 +6,7 @@ on:  # yamllint disable-line rule:truthy
     branches: ['*']
 
 jobs:
-  lcov:
+  summary:
     runs-on: ubuntu-latest
     container:
       image: t4seame/app:latest
@@ -15,8 +15,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run Coverage Script
+      - name: Get coverage summary
         run: |
+          PLATFORM_TARGETS=$(bazel query 'kind("cc_binary|cc_library", //platform/...) except kind(.*test, //...)')
+          MIDDLEWARE_TARGETS=$(bazel query 'kind("cc_binary|cc_library", //com-middleware/...) except kind(.*test, //...)')
+          ALL_TARGETS=$(echo "$PLATFORM_TARGETS $MIDDLEWARE_TARGETS" | tr '\n' ' ')
+
+          echo "All Targets: $ALL_TARGETS"
+
           BAZEL_BIN=$(bazel info bazel-bin)
           TEST_LOGS=$(bazel info bazel-testlogs)
 
@@ -25,7 +31,7 @@ jobs:
 
           bazelisk run //tools/coverage:lcov \
             --platforms=//bazel/platforms:x86_64_linux -- \
-            -b //... \
+            -b "$ALL_TARGETS" \
             -t //:unit_tests \
             -c "$BAZEL_BIN" \
             -d "$TEST_LOGS" \

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -1,12 +1,10 @@
 ---
 name: Docker
-
 on:  # yamllint disable-line rule:truthy
   push:
-    branches:
-      - main
-    paths:
-      - 'Dockerfile'
+    branches: ["main"]
+    paths: ["Dockerfile"]
+  workflow_dispatch:
 
 jobs:
   build_and_push:

--- a/README.md
+++ b/README.md
@@ -353,8 +353,10 @@ bazel run //tools/coverage:lcov -- -t <test_target>
 The GitHub Action for coverage runs the tests defined in the `unit_tests` test suite, in the `BUILD` file located at the root of the project. The coverage report is generated with the following command:
 
 ```bash
-  bazel run //tools/coverage:lcov -- -t :unit_tests
+bazel run //tools/coverage:lcov -- -t <test_target> -b <baseline_target> -o <output_dir> -c $(bazel info bazel-bin) -d $(bazel info bazel-testlogs)
 ```
+
+[See more details in coverage README](tools/coverage/README.md)
 
 ##### Adding Tests to the Coverage Suite
 
@@ -363,9 +365,11 @@ To include a new test target in the coverage calculation, add your test suite ta
 **Organize Tests by Directory**: Each directory should have its own BUILD file defining the relevant test targets for that directory. Avoid adding test targets directly to the `unit_tests` suite in the root `BUILD` file.
 For a reference implementation, see the test setup in `//examples:unit_test`. This example demonstrates how to organize and integrate test targets within the coverage framework.
 
-#### 2.7.3. ToDo - Baseline
+#### 2.7.3. Coverage Report
 
-A baseline mechanism for coverage is not yet implemented but will be added in the future.
+The HTML coverage report is automatically uploaded to a GitHub Page via GitHub Actions whenever changes are merged into the `main` branch.
+
+You can access the coverage report at: <https://seame-pt.github.io/Team04/>
 
 ## 3. Releases
 


### PR DESCRIPTION
## Description

Automate coverage reporting via github pages.
Reports source code of relevant targets, `cc_bins` and `cc_libs` that are flashed to car.

## Checklist

- [x] Code follows project style guidelines.
- [ ] Tests added or updated.
- [x] Documentation updated (if applicable).
- [x] Tested in simulation/real-world environment (if applicable).

## Testing

Report uploaded to [github page](https://seame-pt.github.io/Team04/).

## Related Issue

Issue: https://github.com/SEAME-pt/Team04/issues/141

## Related Issue

Scope of what we intend to include in the coverage report, which `cc_bins` and `cc_libs`, will be further discussed.
