### PR TITLE
ci: add aarch64 and x86 bins to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+# yamllint disable rule:line-length
 ---
 name: Release
 on:  # yamllint disable-line rule:truthy
@@ -20,9 +21,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Build Bazel
-        run: bazel build //:release_bins
-
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -36,13 +34,28 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Upload Release Asset
-        id: upload-release-asset
+      - name: Build for aarch64
+        run: bazel build //:release_bins --platforms=//bazel/platforms:aarch64_linux
+
+      - name: Upload Release arm64 bins
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: bazel-out/k8-fastbuild/bin/release_bins.tar.gz
-          asset_name: release_bins.tar.gz
+          asset_name: aarch64_bins.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Build for x86_64
+        run: bazel build //:release_bins --platforms=//bazel/platforms:x86_64_linux
+
+      - name: Upload Release arm64 bins
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: bazel-out/k8-fastbuild/bin/release_bins.tar.gz
+          asset_name: x86_64_bins.tar.gz
           asset_content_type: application/gzip

--- a/README.md
+++ b/README.md
@@ -387,4 +387,4 @@ After creating the tag locally, push it to the remote repo.
 git push origin v<release version>
 ```
 
-The release includes a `tar.gz` archive containing all `cc_binaries` from `//:release_bins`.
+The release includes a `tar.gz` archive containing all `cc_binaries` cross-compiled for arm64 from `//:release_bins`.


### PR DESCRIPTION
## Description

Include both x86 and arm64 bins in releases.

## Checklist

- [x] Code follows project style guidelines.
- [ ] Tests added or updated.
- [ ] Documentation updated (if applicable).
- [x] Tested in simulation/real-world environment (if applicable).

## Testing

Created a new release: https://github.com/SEAME-pt/Team04/releases/tag/v1.0.0

## Related Issue

Issue: https://github.com/SEAME-pt/jet_racers/issues/38

