### PR TITLE
fix: coverage no source error in baseline

### DIFF
--- a/tools/coverage/lcov.sh
+++ b/tools/coverage/lcov.sh
@@ -122,6 +122,7 @@ main() {
         --directory "${GCNO_DIR}" \
         --capture \
         -i \
+        --ignore-errors source \
         --output-file "${OUTPUT_DIR}/baseline.info"
 
     echo -e "\nINFO: Filter baseline.info"
@@ -133,6 +134,7 @@ main() {
         '*gtest*' \
         --ignore-errors unused \
         --ignore-errors empty \
+        --ignore-errors source \
         --output-file "${OUTPUT_DIR}/baseline_filtered.info"
 
     run_coverage_tests


### PR DESCRIPTION
## Description

Ignore errors caused by external sources not found during baseline creation.
Error can be ignore since it is not intended to gather coverage for external source.

## Checklist

- [x] Code follows project style guidelines.
- [ ] Tests added or updated.
- [ ] Documentation updated (if applicable).
- [ ] Tested in simulation/real-world environment (if applicable).

## Testing

Locally.

## Related Issue

Issue: https://github.com/SEAME-pt/jet_racers/issues/38

