### PR TITLE
coverage: create baseline with filegroup of cc_bins

### DIFF
--- a/.github/workflows/coverage_deploy.yml
+++ b/.github/workflows/coverage_deploy.yml
@@ -34,11 +34,9 @@ jobs:
 
       - name: Generate coverage report
         run: |
-          PLATFORM_TARGETS=$(bazel query 'kind("cc_binary|cc_library", //platform/...) except kind(.*test, //...)')
-          MIDDLEWARE_TARGETS=$(bazel query 'kind("cc_binary|cc_library", //com-middleware/...) except kind(.*test, //...)')
-          ALL_TARGETS=$(echo "$PLATFORM_TARGETS $MIDDLEWARE_TARGETS" | tr '\n' ' ')
-
-          echo "All Targets: $ALL_TARGETS"
+          TARGETS=$(bazel query 'kind("(cc_binary|cc_library)", deps(//:release_bins_filegroup)) except kind(".*test", deps(//:release_bins_filegroup)) intersect filter("^//", deps(//:release_bins_filegroup))')
+          TARGETS_STR=$(echo "$TARGETS" | tr '\n' ' ')
+          echo "Targets used for coverage baseline: $TARGETS_STR"
 
           BAZEL_BIN=$(bazel info bazel-bin)
           TEST_LOGS=$(bazel info bazel-testlogs)
@@ -48,7 +46,7 @@ jobs:
 
           bazelisk run //tools/coverage:lcov \
             --platforms=//bazel/platforms:x86_64_linux -- \
-            -b "$ALL_TARGETS" \
+            -b "$TARGETS_STR" \
             -t //:unit_tests \
             -c "$BAZEL_BIN" \
             -d "$TEST_LOGS" \

--- a/.github/workflows/coverage_summary.yml
+++ b/.github/workflows/coverage_summary.yml
@@ -17,11 +17,9 @@ jobs:
 
       - name: Get coverage summary
         run: |
-          PLATFORM_TARGETS=$(bazel query 'kind("cc_binary|cc_library", //platform/...) except kind(.*test, //...)')
-          MIDDLEWARE_TARGETS=$(bazel query 'kind("cc_binary|cc_library", //com-middleware/...) except kind(.*test, //...)')
-          ALL_TARGETS=$(echo "$PLATFORM_TARGETS $MIDDLEWARE_TARGETS" | tr '\n' ' ')
-
-          echo "All Targets: $ALL_TARGETS"
+          TARGETS=$(bazel query 'kind("(cc_binary|cc_library)", deps(//:release_bins_filegroup)) except kind(".*test", deps(//:release_bins_filegroup)) intersect filter("^//", deps(//:release_bins_filegroup))')
+          TARGETS_STR=$(echo "$TARGETS" | tr '\n' ' ')
+          echo "Targets used for coverage baseline: $TARGETS_STR"
 
           BAZEL_BIN=$(bazel info bazel-bin)
           TEST_LOGS=$(bazel info bazel-testlogs)
@@ -31,7 +29,7 @@ jobs:
 
           bazelisk run //tools/coverage:lcov \
             --platforms=//bazel/platforms:x86_64_linux -- \
-            -b "$ALL_TARGETS" \
+            -b "$TARGETS_STR" \
             -t //:unit_tests \
             -c "$BAZEL_BIN" \
             -d "$TEST_LOGS" \

--- a/BUILD
+++ b/BUILD
@@ -1,18 +1,33 @@
-load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
-pkg_filegroup(
-    name = "release_pkg_filegroup",
+filegroup(
+    name = "release_bins_filegroup",
     srcs = [
-        "//com-middleware:pkg_files",
-        "//examples:pkg_files",
+        "//com-middleware:bin",
+        "//examples:bins_filegroup",
+        "//instrument-cluster:bin",
     ],
+)
+
+pkg_files(
+    name = "pkg_files",
+    srcs = [
+        ":release_bins_filegroup",
+    ],
+    attributes = pkg_attributes(
+        group = "root",
+        mode = "0755",
+        owner = "root",
+    ),
+    strip_prefix = "/",
+    visibility = ["//:__pkg__"],
 )
 
 pkg_tar(
     name = "release_bins",
     srcs = [
-        ":release_pkg_filegroup",
+        ":pkg_files",
     ],
     extension = "tar.gz",
 )

--- a/README.md
+++ b/README.md
@@ -387,4 +387,5 @@ After creating the tag locally, push it to the remote repo.
 git push origin v<release version>
 ```
 
-The release includes a `tar.gz` archive containing all `cc_binaries` cross-compiled for arm64 from `//:release_bins`.
+The release includes a `tar.gz` archive containing the `binaries` compiled for arm64, defined in `//:release_bins_filegroup` target.
+Add a new `cc_binary` to the filegroup to include the binary into the next release.

--- a/com-middleware/BUILD
+++ b/com-middleware/BUILD
@@ -1,5 +1,3 @@
-load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
-
 cc_binary(
     name = "bin",
     srcs = ["src/main.cpp"],
@@ -7,24 +5,11 @@ cc_binary(
     linkopts = [
         "-lzmq",
     ],
+    visibility = ["//:__pkg__"],
     deps = [
         "//com-middleware/src/can",
         "//com-middleware/src/exceptions",
         "//mq",
         "@cppzmq",
     ],
-)
-
-pkg_files(
-    name = "pkg_files",
-    srcs = [
-        ":bin",
-    ],
-    attributes = pkg_attributes(
-        group = "root",
-        mode = "0755",
-        owner = "root",
-    ),
-    strip_prefix = "/",
-    visibility = ["//:__pkg__"],
 )

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,5 +1,3 @@
-load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
-
 filegroup(
     name = "bins_filegroup",
     srcs = [
@@ -9,19 +7,6 @@ filegroup(
         "//examples/qt/qml:bin",
         "//examples/qt/ui:bin",
     ],
-)
-
-pkg_files(
-    name = "pkg_files",
-    srcs = [
-        ":bins_filegroup",
-    ],
-    attributes = pkg_attributes(
-        group = "root",
-        mode = "0755",
-        owner = "root",
-    ),
-    strip_prefix = "/",
     visibility = ["//:__pkg__"],
 )
 

--- a/instrument-cluster/BUILD
+++ b/instrument-cluster/BUILD
@@ -16,6 +16,7 @@ qt_cc_binary(
     linkopts = [
         "-lzmq",
     ],
+    visibility = ["//:__pkg__"],
     deps = [
         ":qrc",
         "//instrument-cluster/qml/ClusterData:backend",

--- a/tools/coverage/lcov.sh
+++ b/tools/coverage/lcov.sh
@@ -161,7 +161,17 @@ main() {
     lcov \
         -a "${OUTPUT_DIR}/baseline_filtered.info" \
         -a "${OUTPUT_DIR}/tests_filtered.info" \
-        -o "${OUTPUT_DIR}/coverage.info"
+        -o "${OUTPUT_DIR}/merge.info"
+
+    echo -e "\nINFO: Filter merge.info"
+    echo -e "\nINFO: Exclude generated files."
+    lcov \
+        --directory "${GCDA_DIR}" \
+        --remove "${OUTPUT_DIR}/merge.info" \
+        "*bazel-out/k8-fastbuild/bin/*" \
+        --ignore-errors unused \
+        --ignore-errors source \
+        --output-file "${OUTPUT_DIR}/coverage.info"
 
     if [ "${SKIP_HTML_REPORT}" = false ]; then
         echo -e "\nINFO: Generating HTML coverage report"


### PR DESCRIPTION
## Description

- Improve project organization by adding a filegroup at root with the bins for target.
- Use the new filegroup to create coverage baseline.
- Dont include qt generate files in the coverage report.

## Checklist

- [x] Code follows project style guidelines.
- [ ] Tests added or updated.
- [x] Documentation updated (if applicable).
- [x] Tested in simulation/real-world environment (if applicable).

## Testing

Coverage report generated: https://seame-pt.github.io/Team04/

## Related Issue

Issue: https://github.com/SEAME-pt/jet_racers/issues/38
