### PR TITLE
bazel: add platform bins to root filegroup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   create-release:
-    name: Create Release
     runs-on: ubuntu-latest
     container:
       image: t4seame/app:latest
@@ -20,25 +19,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Fetch full history for rebase
 
       - name: Configure Git Safe Directory
         run: |
           git config --global --add safe.directory $(pwd)
-
-      - name: Set Git user identity
-        run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions"
-
-      - name: Fetch main branch
-        run: |
-          git fetch origin main
-
-      - name: Rebase PR branch onto main
-        run: |
-          git rebase origin/main || (git rebase --abort && exit 1)
 
       - name: Create Release
         id: create_release

--- a/BUILD
+++ b/BUILD
@@ -7,6 +7,7 @@ filegroup(
         "//com-middleware:bin",
         "//examples:bins_filegroup",
         "//instrument-cluster:bin",
+        "//platform:bins_filegroup",
     ],
 )
 

--- a/platform/BUILD
+++ b/platform/BUILD
@@ -1,0 +1,8 @@
+filegroup(
+    name = "bins_filegroup",
+    srcs = [
+        "//platform/battery-sensor:bin",
+        "//platform/temperature-sensor:bin",
+    ],
+    visibility = ["//:__pkg__"],
+)

--- a/platform/battery-sensor/BUILD
+++ b/platform/battery-sensor/BUILD
@@ -5,7 +5,7 @@ cc_binary(
     linkopts = [
         "-lzmq",
     ],
-    visibility = ["//:__pkg__"],
+    visibility = ["//platform:__pkg__"],
     deps = [
         "//mq",
         "@cppzmq",

--- a/platform/temperature-sensor/BUILD
+++ b/platform/temperature-sensor/BUILD
@@ -5,7 +5,7 @@ cc_binary(
     linkopts = [
         "-lzmq",
     ],
-    visibility = ["//:__pkg__"],
+    visibility = ["//platform:__pkg__"],
     deps = [
         "//mq",
         "@cppzmq",


### PR DESCRIPTION
## Description

- Remove auto rebase with main for release.
- Include `platform/battery-sensor` and `platform/temperature-sensor` binaries  in releases and coverage report.

## Checklist

- [x] Code follows project style guidelines.
- [ ] Tests added or updated.
- [ ] Documentation updated (if applicable).
- [x] Tested in simulation/real-world environment (if applicable).

## Testing

CI.

## Related Issue

Issue: https://github.com/SEAME-pt/jet_racers/issues/38

## Notes

- See updated github page: https://seame-pt.github.io/Team04/
