### PR TITLE
feat: changing speed and rpm to floats

### DIFF
--- a/arduino/speed_receive/speed_receive.ino
+++ b/arduino/speed_receive/speed_receive.ino
@@ -17,7 +17,7 @@
 // Channel 0 SPI_CS Pin: BCM 8
 // Channel 1 SPI_CS Pin: BCM 7
 // Interupt Pin: BCM25
-const int SPI_CS_PIN  = BCM8;
+const int SPI_CS_PIN = BCM8;
 const int CAN_INT_PIN = BCM25;
 #else
 
@@ -28,21 +28,20 @@ const int SPI_CS_PIN = 9;
 const int CAN_INT_PIN = 2;
 #endif
 
-
 #ifdef CAN_2518FD
 #include "mcp2518fd_can.h"
-mcp2518fd CAN(SPI_CS_PIN); // Set CS pin
+mcp2518fd CAN(SPI_CS_PIN);  // Set CS pin
 #endif
 
 #ifdef CAN_2515
 #include "mcp2515_can.h"
-mcp2515_can CAN(SPI_CS_PIN); // Set CS pin
+mcp2515_can CAN(SPI_CS_PIN);  // Set CS pin
 #endif
 
 void setup() {
     SERIAL_PORT_MONITOR.begin(9600);
 
-    while (CAN_OK != CAN.begin(CAN_500KBPS, MCP_8MHz)) {             // init can bus : baudrate = 500k
+    while (CAN_OK != CAN.begin(CAN_500KBPS, MCP_8MHz)) {  // init can bus : baudrate = 500k
         SERIAL_PORT_MONITOR.println("CAN init fail, retry...");
         delay(100);
     }
@@ -53,8 +52,8 @@ void loop() {
     unsigned char len = 0;
     unsigned char buf[8];
 
-    if (CAN_MSGAVAIL == CAN.checkReceive()) {         // check if data coming
-        CAN.readMsgBuf(&len, buf);    // read data,  len: data length, buf: data buf
+    if (CAN_MSGAVAIL == CAN.checkReceive()) {  // check if data coming
+        CAN.readMsgBuf(&len, buf);             // read data,  len: data length, buf: data buf
 
         unsigned long canId = CAN.getCanId();
 
@@ -62,19 +61,13 @@ void loop() {
         SERIAL_PORT_MONITOR.print("Get data from ID: 0x");
         SERIAL_PORT_MONITOR.println(canId, HEX);
 
-        // SPEED
-        byte speed = buf[0];
-        byte distanceUnit = buf[1];
-
-        // RPM
-        byte lowByte = buf[2];
-        byte highByte = buf[3];
-        word rpm = word(highByte, lowByte);
+        float speed;
+        float rpm;
+        memcpy(&speed, buf, sizeof(speed));  // Retrieve speed
+        memcpy(&rpm, buf + 4, sizeof(rpm));  // Retrieve rpm (offset by 4)
 
         SERIAL_PORT_MONITOR.print("SPEED: ");
         SERIAL_PORT_MONITOR.print(speed);
-        SERIAL_PORT_MONITOR.print("\t");
-        SERIAL_PORT_MONITOR.print(distanceUnit == KMPH_SETTING ? "KMPH" : "MPH");
         SERIAL_PORT_MONITOR.print("\t");
         SERIAL_PORT_MONITOR.print("RPM: ");
         SERIAL_PORT_MONITOR.print(rpm);

--- a/arduino/speed_send/speed_send.ino
+++ b/arduino/speed_send/speed_send.ino
@@ -1,5 +1,5 @@
-#include <SPI.h>
 #include <EEPROM.h>
+#include <SPI.h>
 
 // DISTANCES
 #define KMPH_DISTANCE 1000.000
@@ -13,7 +13,7 @@
 
 #define WHEEL_DIAMETER 0.067
 #define CAN_2515
-//#define CAN_2518FD
+// #define CAN_2518FD
 
 // Set SPI CS Pin according to your hardware
 
@@ -22,7 +22,7 @@
 // Channel 0 SPI_CS Pin: BCM 8
 // Channel 1 SPI_CS Pin: BCM 7
 // Interupt Pin: BCM25
-const int SPI_CS_PIN  = BCM8;
+const int SPI_CS_PIN = BCM8;
 const int CAN_INT_PIN = BCM25;
 #else
 
@@ -33,146 +33,142 @@ const int SPI_CS_PIN = 9;
 const int CAN_INT_PIN = 2;
 #endif
 
-
 #ifdef CAN_2518FD
 #include "mcp2518fd_can.h"
-mcp2518fd CAN(SPI_CS_PIN); // Set CS pin
+mcp2518fd CAN(SPI_CS_PIN);  // Set CS pin
 #endif
 
 #ifdef CAN_2515
 #include "mcp2515_can.h"
-mcp2515_can CAN(SPI_CS_PIN); // Set CS pin
+mcp2515_can CAN(SPI_CS_PIN);  // Set CS pin
 #endif
 
 // encoder pin (LM393)
-int encoderPin=3;
+int encoderPin = 3;
 
 // Speed
-const int pulsesPerRevolution = 20; // Pulses per wheel revolution
+const int pulsesPerRevolution = 20;  // Pulses per wheel revolution
 const float CIRCUMFERENCE = PI * WHEEL_DIAMETER;
 volatile unsigned short totalPulses = 0;
 unsigned long startMillis;
 unsigned long currentMillis;
-const unsigned long period = 1000; //the value is a number of milliseconds, ie 1 second
+const unsigned long period = 1000;  // the value is a number of milliseconds, ie 1 second
 
 // Settings
-const unsigned int settingsAddress = 0; //EEPROM address to start reading from
+const unsigned int settingsAddress = 0;  // EEPROM address to start reading from
 byte distanceUnitSetting;
 float distanceUnit;
 
 void setup() {
-  // Start Serial
-  SERIAL_PORT_MONITOR.begin(9600);
-  while(!Serial){};
-  Serial.println();
+    // Start Serial
+    SERIAL_PORT_MONITOR.begin(9600);
+    while (!Serial) {
+    };
+    Serial.println();
 
-  // Fetch UNIT from EEPROM
-  Serial.print("Read byte from EEPROM: ");
-  byte unit;
-  EEPROM.get(settingsAddress, unit);
-  Serial.println(unit, HEX);
-  // On first run, every eeprom address will be prefilled with 0xFF
-  if(unit == 0xFF) {
-    setInitialSettings();
+    // Fetch UNIT from EEPROM
+    Serial.print("Read byte from EEPROM: ");
+    byte unit;
     EEPROM.get(settingsAddress, unit);
-  }
-  setDistanceUnit(unit);
+    Serial.println(unit, HEX);
+    // On first run, every eeprom address will be prefilled with 0xFF
+    if (unit == 0xFF) {
+        setInitialSettings();
+        EEPROM.get(settingsAddress, unit);
+    }
+    setDistanceUnit(unit);
 
-  // Attach interrupt to CAN int pin (to receive messages)
-  attachInterrupt(digitalPinToInterrupt(CAN_INT_PIN), onReceiveCanMessage, FALLING); // start receive interrupt
-  while (CAN_OK != CAN.begin(CAN_500KBPS)) {             // init can bus : baudrate = 500k
-      SERIAL_PORT_MONITOR.println("CAN init fail, retry...");
-      delay(100);
-  }
-  SERIAL_PORT_MONITOR.println("CAN init ok!");
+    // Attach interrupt to CAN int pin (to receive messages)
+    attachInterrupt(digitalPinToInterrupt(CAN_INT_PIN), onReceiveCanMessage,
+                    FALLING);                   // start receive interrupt
+    while (CAN_OK != CAN.begin(CAN_500KBPS)) {  // init can bus : baudrate = 500k
+        SERIAL_PORT_MONITOR.println("CAN init fail, retry...");
+        delay(100);
+    }
+    SERIAL_PORT_MONITOR.println("CAN init ok!");
 
-  // LM393
-  // set the encoder pin
-  pinMode(encoderPin, INPUT);
-  // attach the interrupt for tracking the pulses
-  // one the pulse is detected, onPulse() is called
-  attachInterrupt(digitalPinToInterrupt(encoderPin), onPulse, RISING);
+    // LM393
+    // set the encoder pin
+    pinMode(encoderPin, INPUT);
+    // attach the interrupt for tracking the pulses
+    // one the pulse is detected, onPulse() is called
+    attachInterrupt(digitalPinToInterrupt(encoderPin), onPulse, RISING);
 
-  startMillis = millis(); // initial start time
+    startMillis = millis();  // initial start time
 }
 
 void onReceiveCanMessage() {
-  SERIAL_PORT_MONITOR.println("received message");
-  unsigned char len = 0;
-  unsigned char buf[8];
-  // iterate over all pending messages
-  // If either the bus is saturated or the MCU is busy,
-  // both RX buffers may be in use and reading a single
-  // message does not clear the IRQ conditon.
-  while (CAN_MSGAVAIL == CAN.checkReceive()) {
-      // read data,  len: data length, buf: data buf
-      SERIAL_PORT_MONITOR.println("checkReceive");
-      CAN.readMsgBuf(&len, buf);
-      unsigned long canId = CAN.getCanId();
-      SERIAL_PORT_MONITOR.println(canId, HEX);
+    SERIAL_PORT_MONITOR.println("received message");
+    unsigned char len = 0;
+    unsigned char buf[8];
+    // iterate over all pending messages
+    // If either the bus is saturated or the MCU is busy,
+    // both RX buffers may be in use and reading a single
+    // message does not clear the IRQ conditon.
+    while (CAN_MSGAVAIL == CAN.checkReceive()) {
+        // read data,  len: data length, buf: data buf
+        SERIAL_PORT_MONITOR.println("checkReceive");
+        CAN.readMsgBuf(&len, buf);
+        unsigned long canId = CAN.getCanId();
+        SERIAL_PORT_MONITOR.println(canId, HEX);
 
-      switch(canId) {
-        case SETTINGS_MESSAGE_ID:
-          changeSettings(buf, len);
-          break;
-        default:
-          SERIAL_PORT_MONITOR.println("invalid can message");
-          break;
-      }
-  }
+        switch (canId) {
+            case SETTINGS_MESSAGE_ID:
+                changeSettings(buf, len);
+                break;
+            default:
+                SERIAL_PORT_MONITOR.println("invalid can message");
+                break;
+        }
+    }
 }
 
 byte canMessage[4] = {0, 0, 0, 0};
 void loop() {
-  currentMillis = millis();  //get the current "time" (actually the number of milliseconds since the program started)
-  if (currentMillis - startMillis >= period)  //test whether the period has elapsed
-  {
-    word rpm = getRPM();
-    byte speed = calculateSpeed(rpm);
-    sendSpeedMessage(rpm, speed);
-    totalPulses = 0; // Reset the total number of pulses
-    startMillis = currentMillis;  //IMPORTANT to save the start time of the current state.
-  }
-}
-
-void onPulse(){
-         // increment the total number of pulses
-        totalPulses++;
-}
-
-void sendSpeedMessage(word rpm, byte speed) {
-  // Assign the byte value to the first byte of the message
-  canMessage[0] = speed;
-  canMessage[1] = distanceUnitSetting;
-
-  // Assign the short value to the next two bytes of the message
-  canMessage[2] = lowByte(rpm);
-  canMessage[3] = highByte(rpm);
-
-  byte res = CAN.sendMsgBuf(SPEED_MESSAGE_ID, 0, 4, canMessage);
-
-  if(CAN_OK != res) {
-    SERIAL_PORT_MONITOR.println("CAN BUS sendMsgBuf fail!");
-    switch(res)
+    currentMillis = millis();  // get the current "time" (actually the number of milliseconds since
+                               // the program started)
+    if (currentMillis - startMillis >= period)  // test whether the period has elapsed
     {
-      case CAN_FAILTX:
-        SERIAL_PORT_MONITOR.println("CAN_FAILTX");
-        break;
-      case CAN_GETTXBFTIMEOUT:
-        SERIAL_PORT_MONITOR.println("CAN_GETTXBFTIMEOUT");
-        break;
-      case CAN_SENDMSGTIMEOUT:
-        SERIAL_PORT_MONITOR.println("CAN_SENDMSGTIMEOUT");
-        break;
-      default:
-        SERIAL_PORT_MONITOR.println("Unknown Error");
-        break;
-
+        float rpm = getRPM();
+        float speed = calculateSpeed(rpm);
+        sendSpeedMessage(rpm, speed);
+        totalPulses = 0;              // Reset the total number of pulses
+        startMillis = currentMillis;  // IMPORTANT to save the start time of the current state.
     }
-  }
-  else {
-    SERIAL_PORT_MONITOR.println("CAN BUS sendMsgBuf ok!");
-  }
+}
+
+void onPulse() {
+    // increment the total number of pulses
+    totalPulses++;
+}
+
+void sendSpeedMessage(float rpm, float speed) {
+    // 4 first bytes - speed
+    memcpy(canMessage, &speed, sizeof(speed));
+    // last 4 bytes - rpm
+    memcpy(canMessage + 4, &rpm, sizeof(rpm));
+
+    byte res = CAN.sendMsgBuf(SPEED_MESSAGE_ID, 0, 8, canMessage);
+
+    if (CAN_OK != res) {
+        SERIAL_PORT_MONITOR.println("CAN BUS sendMsgBuf fail!");
+        switch (res) {
+            case CAN_FAILTX:
+                SERIAL_PORT_MONITOR.println("CAN_FAILTX");
+                break;
+            case CAN_GETTXBFTIMEOUT:
+                SERIAL_PORT_MONITOR.println("CAN_GETTXBFTIMEOUT");
+                break;
+            case CAN_SENDMSGTIMEOUT:
+                SERIAL_PORT_MONITOR.println("CAN_SENDMSGTIMEOUT");
+                break;
+            default:
+                SERIAL_PORT_MONITOR.println("Unknown Error");
+                break;
+        }
+    } else {
+        SERIAL_PORT_MONITOR.println("CAN BUS sendMsgBuf ok!");
+    }
 }
 
 /**
@@ -180,58 +176,52 @@ void sendSpeedMessage(word rpm, byte speed) {
   RPM = Rotations (totalPulses/pulsesPerRevolution) * minute (ms) / period (ms)
 
 */
-word getRPM() {
-  return (totalPulses / (float) pulsesPerRevolution) * (60000.0 / period);
-}
+float getRPM() { return (totalPulses / (float)pulsesPerRevolution) * (60000.0f / period); }
 
 /**
 
   Speed (km/h) = angular speed * circumference * (60 / 1000)
 
 */
-byte calculateSpeed(word rpm) {
-  return round(rpm * CIRCUMFERENCE * 60.0 / distanceUnit) & 0xff;
-}
+float calculateSpeed(float rpm) { return rpm * CIRCUMFERENCE * 60.0 / distanceUnit; }
 
 void setInitialSettings() {
-  Serial.println("Setting initial settings.");
-  EEPROM.put(settingsAddress, KMPH_SETTING);
+    Serial.println("Setting initial settings.");
+    EEPROM.put(settingsAddress, KMPH_SETTING);
 }
 
 void changeSettings(unsigned char* buf, unsigned int len) {
-  if(len == 0) {
-    return;
-  }
+    if (len == 0) {
+        return;
+    }
 
-  SERIAL_PORT_MONITOR.println("Changing settings");
-  byte unit = buf[0] & 0x01;
+    SERIAL_PORT_MONITOR.println("Changing settings");
+    byte unit = buf[0] & 0x01;
 
-  if(setDistanceUnit(unit)) {
-    setDistanceSetting(unit);
-  }
+    if (setDistanceUnit(unit)) {
+        setDistanceSetting(unit);
+    }
 }
 
-void setDistanceSetting(byte setting) {
-  EEPROM.put(settingsAddress, setting);
-}
+void setDistanceSetting(byte setting) { EEPROM.put(settingsAddress, setting); }
 
 bool setDistanceUnit(byte unit) {
-  switch(unit) {
-    case KMPH_SETTING:
-      SERIAL_PORT_MONITOR.println("setting to kmph");
-      distanceUnitSetting = KMPH_SETTING;
-      distanceUnit = KMPH_DISTANCE;
-      break;
-    case MPH_SETTING:
-      SERIAL_PORT_MONITOR.println("setting to mph");
-      distanceUnitSetting = MPH_SETTING;
-      distanceUnit = MPH_DISTANCE;
-      break;
-    default:
-      SERIAL_PORT_MONITOR.println("invalid unit");
-      return false;
-  }
-  return true;
+    switch (unit) {
+        case KMPH_SETTING:
+            SERIAL_PORT_MONITOR.println("setting to kmph");
+            distanceUnitSetting = KMPH_SETTING;
+            distanceUnit = KMPH_DISTANCE;
+            break;
+        case MPH_SETTING:
+            SERIAL_PORT_MONITOR.println("setting to mph");
+            distanceUnitSetting = MPH_SETTING;
+            distanceUnit = MPH_DISTANCE;
+            break;
+        default:
+            SERIAL_PORT_MONITOR.println("invalid unit");
+            return false;
+    }
+    return true;
 }
 
 // END FILE

--- a/com-middleware/src/main.cpp
+++ b/com-middleware/src/main.cpp
@@ -86,16 +86,6 @@ auto main(int argc, char **argv) -> int {
 
         // The len element contains the payload length in bytes and should be used instead of
         // can_dlc
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-        printf("0x%03X [%d] ", frame.can_id, frame.len);
-
-        for (int i = 0; i < frame.len; i++) {
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
-            std::cout << printf("%02X ", frame.data[i]);
-        }
-
-        std::cout << "\n";
-
         std::vector<uint8_t> message(frame.len + 1);
         message[0] = static_cast<uint8_t>(frame.can_id);
         memcpy(message.data() + 1, frame.data, static_cast<size_t>(num_bytes));

--- a/docs/communication.md
+++ b/docs/communication.md
@@ -4,18 +4,17 @@
 
 ID: 0x01
 
-Data: Speed on byte 0, Unit on byte 1, RPM on bytes 2 and 3 (stored in little endian)
+Data: Speed on bytes 0 through 4 (float), RPM on bytes 5 through 8 (float), both stored in little endian
 
 Example: 
 
     ID: 0x01
-    Length: 4
-    Data: 0x01 0x00 0x2C 0x01 0x00 0x00 0x00 0x00
+    Length: 8
+    Data: 0x40 0x90 0x00 0x00 0x43 0xad 0x00 0x00
 
     which translates to:
-    - Speed: 1
-    - Unit: 0x00 (km/h)
-    - RPM: 300
+    - Speed: 4.5
+    - RPM: 346
 
 ### 🔧 Settings Change Message
 

--- a/instrument-cluster/Main.qml
+++ b/instrument-cluster/Main.qml
@@ -5,7 +5,7 @@ import Constants
 ApplicationWindow {
     height: Constants.height
     title: qsTr("Instrument Cluster")
-    visibility: "FullScreen"
+    visibility: SIMULATION_MODE ? "AutomaticVisibility" : "FullScreen"
     visible: true
     width: Constants.width
 

--- a/instrument-cluster/main.cpp
+++ b/instrument-cluster/main.cpp
@@ -34,6 +34,7 @@ auto main(int argc, char *argv[]) -> int {
     engine.rootContext()->setContextProperty("SIMULATION_MODE", QVariant(true));
 #else
     engine.rootContext()->setContextProperty("SIMULATION_MODE", QVariant(false));
+    QGuiApplication::setOverrideCursor(QCursor(Qt::BlankCursor));
 #endif
 
     engine.load(QUrl(QStringLiteral("qrc:/instrument-cluster/Main.qml")));
@@ -42,6 +43,5 @@ auto main(int argc, char *argv[]) -> int {
     std::signal(SIGTERM, sigHandler);
     std::signal(SIGSEGV, sigHandler);
     std::signal(SIGABRT, sigHandler);
-    QGuiApplication::setOverrideCursor(QCursor(Qt::BlankCursor));
     return QGuiApplication::exec();
 }

--- a/instrument-cluster/mq/ZMQSubscriber.cpp
+++ b/instrument-cluster/mq/ZMQSubscriber.cpp
@@ -50,11 +50,11 @@ void ZmqSubscriber::decodeMessage(const std::vector<uint8_t> &message) {
 
     switch (message[0]) {
         case 1: {
-            uint8_t const speed_value = message[1];
-            uint8_t const rpm_low_byte = message[3];
-            uint8_t const rpm_high_byte = message[4];
-            uint16_t const rpm = (rpm_high_byte << 8) | rpm_low_byte;
-            emit messageReceived(speed_value, rpm);
+            float speed;
+            float rpm;
+            memcpy(&speed, message.data() + 1, sizeof(speed));  // Retrieve speed
+            memcpy(&rpm, message.data() + 5, sizeof(rpm));      // Retrieve rpm (offset by 5)
+            emit messageReceived(speed, rpm);
             break;
         }
         case 2: {

--- a/instrument-cluster/mq/ZMQSubscriber.hpp
+++ b/instrument-cluster/mq/ZMQSubscriber.hpp
@@ -15,7 +15,7 @@ class ZmqSubscriber : public QObject {
     ~ZmqSubscriber() override;
 
    signals:
-    void messageReceived(uint8_t speed, uint16_t rpm);
+    void messageReceived(float speed, float rpm);
     void batteryMessageReceived(uint8_t battery);
     void temperatureMessageReceived(uint8_t temperature);
 

--- a/instrument-cluster/qml/ClusterData/Backend.qml
+++ b/instrument-cluster/qml/ClusterData/Backend.qml
@@ -82,15 +82,15 @@ Item {
         }
     }
     property date __currentTime: new Date()
-    property real battery: SIMULATION_MODE ? 0 : dataManager.battery
+    property real battery: SIMULATION_MODE ? 0.0 : dataManager.battery
     property int hours: 0
     property bool metricSystem: true
     property int minutes: 0
     readonly property real ratioKMtoM: 0.62137
-    property real rpm: SIMULATION_MODE ? 0 : dataManager.rpm
+    property real rpm: SIMULATION_MODE ? 0.0 : dataManager.rpm
     property int seconds: 0
     property real speed: SIMULATION_MODE ? 0 : dataManager.speed
-    property real speedComputed: backend.metricSystem ? (backend.speed * backend.ratioKMtoM) : backend.speed
+    property real speedComputed: backend.metricSystem ? speed : (speed * backend.ratioKMtoM)
     property real temperature: SIMULATION_MODE ? 0 : dataManager.temperature
     property string time: ""
 

--- a/instrument-cluster/src/DataManager.cpp
+++ b/instrument-cluster/src/DataManager.cpp
@@ -38,14 +38,14 @@ DataManager::~DataManager() {
     qDebug() << "DataManager::finished";
 }
 
-void DataManager::setSpeed(uint8_t speed) {
+void DataManager::setSpeed(float speed) {
     if (m_speed != speed) {
         m_speed = speed;
         emit speedChanged();
     }
 }
 
-void DataManager::setRpm(uint16_t rpm) {
+void DataManager::setRpm(float rpm) {
     if (m_rpm != rpm) {
         m_rpm = rpm;
         emit rpmChanged();
@@ -66,7 +66,7 @@ void DataManager::setTemperature(uint8_t temperature) {
     }
 }
 
-void DataManager::updateData(uint8_t speed, uint16_t rpm) {
+void DataManager::updateData(float speed, float rpm) {
     setSpeed(speed);
     setRpm(rpm);
 }

--- a/instrument-cluster/src/DataManager.hpp
+++ b/instrument-cluster/src/DataManager.hpp
@@ -12,8 +12,8 @@ class DataManager : public QObject {
     // NOLINTNEXTLINE(modernize-use-trailing-return-type)
     Q_OBJECT
     QML_ELEMENT
-    Q_PROPERTY(uint8_t speed READ speed WRITE setSpeed NOTIFY speedChanged)
-    Q_PROPERTY(uint16_t rpm READ rpm WRITE setRpm NOTIFY rpmChanged)
+    Q_PROPERTY(float speed READ speed WRITE setSpeed NOTIFY speedChanged)
+    Q_PROPERTY(float rpm READ rpm WRITE setRpm NOTIFY rpmChanged)
     Q_PROPERTY(uint8_t battery READ battery WRITE setBattery NOTIFY batteryChanged)
     Q_PROPERTY(uint8_t temperature READ temperature WRITE setTemperature NOTIFY temperatureChanged)
 
@@ -21,18 +21,18 @@ class DataManager : public QObject {
     explicit DataManager(QObject* parent = nullptr);
     ~DataManager() override;
 
-    [[nodiscard]] auto speed() const -> uint8_t { return m_speed; }
-    void setSpeed(uint8_t speed);
+    [[nodiscard]] auto speed() const -> float { return m_speed; }
+    void setSpeed(float speed);
 
-    [[nodiscard]] auto rpm() const -> uint16_t { return m_rpm; }
-    void setRpm(uint16_t rpm);
+    [[nodiscard]] auto rpm() const -> float { return m_rpm; }
+    void setRpm(float rpm);
 
     [[nodiscard]] auto battery() const -> uint8_t { return m_battery; }
 
     [[nodiscard]] auto temperature() const -> uint8_t { return m_temperature; }
 
    private slots:
-    void updateData(uint8_t speed, uint16_t rpm);
+    void updateData(float speed, float rpm);
     void setTemperature(uint8_t temperature);
     void setBattery(uint8_t battery);
 
@@ -44,8 +44,8 @@ class DataManager : public QObject {
     void startZeroMQ();
 
    private:
-    uint8_t m_speed = 0;
-    uint16_t m_rpm = 0;
+    float m_speed = 0;
+    float m_rpm = 0;
     uint8_t m_battery = 0;
     uint8_t m_temperature = 0;
     QThread* thread;

--- a/mq/src/ZeroMQSocket.cpp
+++ b/mq/src/ZeroMQSocket.cpp
@@ -47,11 +47,7 @@ auto ZeroMQSocket::send(const std::vector<uint8_t>& data) -> bool {
     zmq::message_t msg(data.size());
     memcpy(msg.data(), data.data(), data.size());
     auto res = m_socket.send(msg, zmq::send_flags::none);
-    if (res.has_value()) {
-        std::cout << "!sent\n";
-        return true;
-    }
-    return false;
+    return res.has_value();
 }
 
 auto ZeroMQSocket::receive() -> std::optional<std::vector<uint8_t>> {

--- a/platform/battery-sensor/main.cpp
+++ b/platform/battery-sensor/main.cpp
@@ -30,12 +30,12 @@ auto main() -> int {
         return 1;
     }
 
-    uint8_t battery = 0;
+    uint8_t battery = 100;
 
     catchSignals();
-    while (true) {
+    while (battery > 0) {
         try {
-            publisher.send({2, battery++});
+            publisher.send({2, battery--});
         } catch (zmq::error_t &e) {
             if (ETERM == e.num()) {
                 break;
@@ -46,7 +46,7 @@ auto main() -> int {
             std::cout << "interrupt received, killing program...\n";
             break;
         }
-        sleep(1);
+        sleep(10);
     }
 
     return 0;

--- a/platform/speed-simulator/BUILD
+++ b/platform/speed-simulator/BUILD
@@ -1,0 +1,13 @@
+cc_binary(
+    name = "bin",
+    srcs = ["main.cpp"],
+    features = ["warnings_critical_code_gcc"],
+    linkopts = [
+        "-lzmq",
+    ],
+    visibility = ["//:__pkg__"],
+    deps = [
+        "//mq",
+        "@cppzmq",
+    ],
+)

--- a/platform/speed-simulator/main.cpp
+++ b/platform/speed-simulator/main.cpp
@@ -30,12 +30,18 @@ auto main() -> int {
         return 1;
     }
 
-    uint8_t temperature = 0;
+    float speed = 0;
+    float rpm = 0;
+
+    std::vector<uint8_t> message(9);
+    message[0] = static_cast<uint8_t>(1);
 
     catchSignals();
-    while (temperature < 110) {
+    while (speed < 15) {
+        std::memcpy(message.data() + 1, &speed, sizeof(speed));
+        std::memcpy(message.data() + 1 + sizeof(float), &rpm, sizeof(rpm));
         try {
-            publisher.send({3, temperature++});
+            publisher.send(message);
         } catch (zmq::error_t &e) {
             if (ETERM == e.num()) {
                 break;
@@ -46,7 +52,9 @@ auto main() -> int {
             std::cout << "interrupt received, killing program...\n";
             break;
         }
-        sleep(10);
+        speed += 0.2F;
+        rpm += 20.2F;
+        usleep(100000);
     }
 
     return 0;


### PR DESCRIPTION
## Description

- Changed speed and rpm to floats. The can message of 8 bytes now contain only the speed and rpm in each 4 bytes.
- Changed instrument cluster to handle new message format
- Created a speed simulator for seeing real time changes

## Checklist

- [x] Code follows project style guidelines.
- [x] Tests added or updated.
- [x] Documentation updated (if applicable).
- [x] Tested in simulation/real-world environment (if applicable).

## Testing

- Tested locally

## Related Issue

#85 

## Notes

N/A
