### PR TITLE
toolchain: add python packages required for lane detection

### DIFF
--- a/third_party/python/requirements.txt
+++ b/third_party/python/requirements.txt
@@ -1,1 +1,3 @@
 tabulate==0.9.0
+numpy==2.2.4
+scipy==1.15.2

--- a/third_party/python/requirements.txt
+++ b/third_party/python/requirements.txt
@@ -1,6 +1,7 @@
 tabulate==0.9.0
 numpy==2.2.4
 scipy==1.15.2
+opencv-python==4.11.0.86
 
 # matplotlib and deps
 python-dateutil==2.9.0.post0

--- a/third_party/python/requirements.txt
+++ b/third_party/python/requirements.txt
@@ -1,3 +1,15 @@
 tabulate==0.9.0
 numpy==2.2.4
 scipy==1.15.2
+
+# matplotlib and deps
+python-dateutil==2.9.0.post0
+six==1.17.0
+kiwisolver==1.4.8
+pyparsing==3.2.3
+cycler==0.12.1
+pillow==11.1.0
+fonttools==4.56.0
+contourpy==1.3.1
+packaging==24.2
+matplotlib==3.10.1


### PR DESCRIPTION
## Description

- Add numpy, scipy, matplotlib and opencv python packages.
- See this [example](https://github.com/SEAME-pt/Team04/blob/2d312a704ad4f346457d5396a1f858ee4d08aca0/tools/coverage/utils/BUILD#L1) for adding a package dependency in the BUILD file.

## Checklist

- [x] Code follows project style guidelines.
- [ ] Tests added or updated.
- [ ] Documentation updated (if applicable).
- [x] Tested in simulation/real-world environment (if applicable).

## Testing

- Tested locally running simple example.

## Related Issue

Issue: https://github.com/SEAME-pt/Team04/issues/192

## Notes

Python package repository: https://pypi.org

